### PR TITLE
Adjusted docs to GitHub pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,6 @@ jobs:
         shell: julia --color=yes --project=docs/ {0}
         run: |
           using Pkg
-          Pkg.add(url="https://github.com/sintefore/TimeStruct.jl")
           Pkg.add(url="https://github.com/EnergyModelsX/EnergyModelsBase.jl")
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@ Version 0.7.1 (2023-06-16)
 Version 0.7.0 (2023-06-06)
 --------------------------
 ### Switch to TimeStruct.jl
- * Switched the time structure representation to [TimeStruct.jl](https://gitlab.sintef.no/julia-one-sintef/timestruct.jl)
+ * Switched the time structure representation to [TimeStruct.jl](https://github.com/sintefore/TimeStruct.jl)
  * TimeStruct.jl is implemented with only the basis features that were available in TimesStructures.jl. This implies that neither operational nor strategic uncertainty is included in the model.
 
 Version 0.6.1 (2023-06-02)
@@ -56,7 +56,7 @@ Version 0.4.0 (2023-02-xx)
 * Variables are now indexed _via_ the `TransmissionMode` and the time period instead of the using a `SparseAxisArray` and indexing _via_ `Transmission`, time period, and `TransmissionMode`. This also improves model generation time.
 * This adjustment requires the declaration of a new instance for each usage of a `TransmissionMode`, see, _e.g._, the changes in `scr\user_interface.jl`.
 ### Additional changes
-* Change of variable generation for individual transmission modes: Variable generation _via_ the function `variables_trans_mode(s)` is adjusted to follow the concept introduced in `EnergyModelsBase`  commit [c58804ca](https://gitlab.sintef.no/clean_export/energymodelsbase.jl/-/commit/c58804cae6415f9a3da05f2d43cfbf5c78525c91).
+* Change of variable generation for individual transmission modes: Variable generation _via_ the function `variables_trans_mode(s)` is adjusted to follow the concept introduced in `EnergyModelsBase`.
 * Move of the field `Data` from `Transmission` to `TransmissionMode`. This is required for the later application of dispatching in `EnergyModelsInvestments`
 
 Version 0.3.1 (2023-02-16)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # EnergyModelsGeography
 
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://energymodelsx.github.io/EnergyModelsGeography.jl//stable)
+[![In Development](https://img.shields.io/badge/docs-dev-blue.svg)](https://energymodelsx.github.io/EnergyModelsGeography.jl/dev/)
+
 `EnergyModelsGeography` is a package to add a geographic representation to [`EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl).
 `EnergyModelsGeography` follows the same philosophy as `EnergyModelsBase` so that it should be easy to create new transmission options or area descriptions.
 
-> **Note**
-> We migrated recently from an internal Git solution to GitHub, including the package [`TimeStruct`](https://github.com/sintefore/TimeStruct.jl). As both `TimeStruct` and `EnergyModelsBase` are not yet registered, it is not possible to build automatically the documentation or run the tests without significant changes in the CI. Every user is however free to build the documentation from the [`docs`](docs) folder.
+> **Note:**
 >
+> We migrated recently from an internal Git solution to GitHub, including the package [`EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl).
+> As `EnergyModelsBase` is not yet registered, it is not possible to run the tests without significant changes in the CI.\> Hence, we plan to wait with creating a release to be certain the tests are running.
+> As a result, the stable docs are not yet available.
+> This may impact as well some links.
+
 ## Usage
 
-The documentation for `EnergyModelsGeography` is currently not uploaded as we migrated recently to GitHub.
-Once `TimeStruct` and `EnergyModelsBase` are registered in the Julia Registry, we will update the README.md  and add the links to the documentation.
-
-See examples of usage of the package and a simple guide for running them in the folder [`examples`](examples).
+The usage of the package is based illustrated through the commented [`examples`](examples).
 
 ## Cite
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
+EnergyModelsGeography = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
-EnergyModelsGeography = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@
 EnergyModelsGeography
 ```
 
-The Julia package extends  [`EnergyModelsBase.jl`](https://clean_export.pages.sintef.no/energymodelsbase.jl/) with functionality to set up an energy system consisting of several separate regions, with transmissions between.
+The Julia package extends [`EnergyModelsBase.jl`](https://energymodelsx.github.io/EnergyModelsBase.jl/) with functionality to set up an energy system consisting of several separate regions, with transmissions between.
 
 The extension focuses on overriding the function `EMB.create_model` to add additional types, variables, and constraints to the model.
 

--- a/docs/src/manual/quick-start.md
+++ b/docs/src/manual/quick-start.md
@@ -1,20 +1,21 @@
-# Quick Start
+# [Quick Start]@(id quick_start)
 
->  1. Install the most recent version of *[Julia](https://julialang.org/downloads/)*.
->  2. Add the *[CleanExport internal Julia registry](https://gitlab.sintef.no/clean_export/registrycleanexport)*:
+>  1. Install the most recent version of [Julia](https://julialang.org/downloads/)
+>  2. Install the package [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/) and the time package [`TimeStruct`](https://sintefore.github.io/TimeStruct.jl/), by running:
 >     ```
->     ] registry add git@gitlab.sintef.no:clean_export/registrycleanexport.git
->     ```
->  3. Add the *[SINTEF internal Julia registry](https://gitlab.sintef.no/julia-one-sintef/onesintef)*:
->     ```
->     ] registry add git@gitlab.sintef.no:julia-one-sintef/onesintef.git
->     ```
->  4. Install the base package [`EnergyModelsBase.jl`](https://clean_export.pages.sintef.no/energymodelsbase.jl/) and the time package [`TimeStruct.jl`](https://gitlab.sintef.no/julia-one-sintef/timestruct.jl), and the geography package [`EnergyModelsGeography.jl`](https://clean_export.pages.sintef.no/energymodelsgeography.jl/) by running:
->     ```
->     ] add EnergyModelsBase
->     ] add EnergyModelsGeography
 >     ] add TimeStruct
+>     ] add EnergyModelsBase
 >     ```
->     This will fetch the packages from the CleanExport package and OneSINTEF registries.
+>     These packages are required as we do not only use them internally, but also for building a model.
+>  3. Install the package [`EnergyModelsGeography`](https://energymodelsx.github.io/EnergyModelsGeography.jl/)
+>     ```
+>     ] add EnergyModelsGeography
+>     ```
 
-Once the package is installed, you can start by using an existing model from `EnergyModelsBase`. The only change that is needed is to substitute the `GenAvailabilty` from `EnergyModelsBase` with `GeoAvailability`from `EnergyModelsGeography`. The `GeoAvailability` node from this local system is then connected to an `RefArea`. More areas can be created by repeating this process. `Transmission` can be added in a system with several areas. `Transmission` have one `From` `Area` one `To` `Area`. It also includes an Array of `TransmissionModes`, which describes how resources are tranported.
+!!! note
+    If you receive the error that one of the packages is not yet registered, you have to add the packages using the GitHub repositories through
+    ```
+    ] add https://github.com/EnergyModelsX/EnergyModelsBase.jl
+    ] add https://github.com/EnergyModelsX/EnergyModelsGeography.jl
+    ```
+    Once the packages are registered, this is not required.

--- a/docs/src/manual/simple-example.md
+++ b/docs/src/manual/simple-example.md
@@ -4,27 +4,7 @@ For the content of the individual examples, see the *[examples](https://gitlab.s
 
 ## The package is installed with `] add`
 
-First, add the *[Clean Export Julia packages repository](https://gitlab.sintef.no/clean_export/registrycleanexport)*.
-Then run
-
-```
-~/some/directory/ $ julia           # Starts the Julia REPL
-julia> ]                            # Enter Pkg mode
-pkg> add EnergyModelsGeography      # Install the package EnergyModelsGeography to the current environment.
-```
-
 From the Julia REPL, run
-
-```julia
-# Starts the Julia REPL
-julia> using EnergyModelsGeography
-# Get the path of the examples directory
-julia> exdir = joinpath(pkgdir(EnergyModelsGeography), "examples")
-# Include the code into the Julia REPL to run the examples
-julia> include(joinpath(exdir, "sink_source.jl"))
-```
-
-The second example can be run using
 
 ```julia
 # Starts the Julia REPL
@@ -37,7 +17,6 @@ julia> include(joinpath(exdir, "network.jl"))
 
 ## The code was downloaded with `git clone`
 
-First, add the internal *[Clean Export Julia package registry](https://gitlab.sintef.no/clean_export/registrycleanexport)*.
 The examples can then be run from the terminal with
 
 ```shell script

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,11 @@
 # Running the examples
 
-## The package is installed with `] add`
+You have to add the packages `EnergyModelsGeography` to your current project in order to run the examples.
+It is not necessary to add the other used packages, as the example is instantiating itself.
+How to add packages is explained in the *[Quick start](https://energymodelsx.github.io/EnergyModelsGeography.jl/stable/manual/quick-start/)* of the documentation
 
-First, add the [*Clean Export* Julia packages repository](https://gitlab.sintef.no/clean_export/registrycleanexport). Then run 
-```
-~/some/directory/ $ julia           # Starts the Julia REPL
-julia> ]                            # Enter Pkg mode 
-pkg> add EnergyModelsGeography      # Install the package EnergyModelsGeography to the current environment.
-```
-From the Julia REPL, run
+You can run from the Julia REPL the following code:
+
 ```julia
 # Starts the Julia REPL
 julia> using EnergyModelsGeography
@@ -16,11 +13,4 @@ julia> using EnergyModelsGeography
 julia> exdir = joinpath(pkgdir(EnergyModelsGeography), "examples")
 # Include the code into the Julia REPL to run the examples
 julia> include(joinpath(exdir, "network.jl"))
-```
-
-## The code was downloaded with `git clone`
-
-First, add the internal [*Clean Export* Julia package registry](https://gitlab.sintef.no/clean_export/registrycleanexport). The examples can then be run from the terminal with
-```shell script
-~/.../energymodelgeography.jl/examples $ julia network.jl
 ```

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -1,9 +1,9 @@
 using Pkg
-# Activate the test-environment, where PrettyTables and HiGHS are added as dependencies.
+# Activate the test-environment, where HiGHS is added as dependency.
 Pkg.activate(joinpath(@__DIR__, "../test"))
 # Install the dependencies.
 Pkg.instantiate()
-# Add the package EnergyModelsInvestments to the environment.
+# Add the package EnergyModelsGeography to the environment.
 Pkg.develop(path=joinpath(@__DIR__, ".."))
 
 using EnergyModelsBase


### PR DESCRIPTION
The docs still included a significant number of internal links to SINTEF pages.
These links were updated to the corresponding GitHub repositories and their documentation.
In addition, the examples section was updated for simpler runs by the user.