### PR TITLE
Add GitHub CI and minor changes in types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         # only test on a subset of possible platforms.
         include:
           - version: '1'  # The latest point-release (Linux)
+            os: ubuntu-latest
             arch: x64
           - version: '1'  # The latest point-release (Windows)
             os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Since EnergyModelsGeography doesn't have binary dependencies,
+        # only test on a subset of possible platforms.
+        include:
+          - version: '1'  # The latest point-release (Linux)
+            arch: x64
+          - version: '1'  # The latest point-release (Windows)
+            os: windows-latest
+            arch: x64
+          - version: '1.9'  # 1.9 
+            os: ubuntu-latest
+            arch: x64
+          - version: '1.9'  # 1.9
+            os: ubuntu-latest
+            arch: x86
+          - version: 'nightly'
+            os: ubuntu-latest
+            arch: x64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: error
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v3
+        with:
+          file: lcov.info

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,6 @@ jobs:
         shell: julia --color=yes --project=docs/ {0}
         run: |
           using Pkg
-          Pkg.add(url="https://github.com/EnergyModelsX/EnergyModelsBase.jl")
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
       - name: Build and deploy

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 Release notes
 =============
+Version 0.8.1 (2024-01-30)
+--------------------------
+ * Updated the restrictions on the fields of individual types to be more restrictive.
+
 Version 0.8.0 (2023-12-19)
 --------------------------
 Adjusted to changes in `EnergyModelsBase` v0.6.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsGeography"
 uuid = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 authors = ["Espen Flo Bødal <Espen.Bodal@sintef.no>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/README.md
+++ b/README.md
@@ -1,28 +1,25 @@
 # EnergyModelsGeography
 
+[![Build Status](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/workflows/CI/badge.svg)](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/actions?query=workflow%3ACI)
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://energymodelsx.github.io/EnergyModelsGeography.jl//stable)
 [![In Development](https://img.shields.io/badge/docs-dev-blue.svg)](https://energymodelsx.github.io/EnergyModelsGeography.jl/dev/)
 
 `EnergyModelsGeography` is a package to add a geographic representation to [`EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl).
 `EnergyModelsGeography` follows the same philosophy as `EnergyModelsBase` so that it should be easy to create new transmission options or area descriptions.
 
-> **Note:**
->
-> We migrated recently from an internal Git solution to GitHub, including the package [`EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl).
-> As `EnergyModelsBase` is not yet registered, it is not possible to run the tests without significant changes in the CI.\> Hence, we plan to wait with creating a release to be certain the tests are running.
-> As a result, the stable docs are not yet available.
-> This may impact as well some links.
-
 ## Usage
 
-The usage of the package is based illustrated through the commented [`examples`](examples).
+The usage of the package is best illustrated through the commented [`examples`](examples).
+The current example shows how to add geographical information to an energy system model built using `EnergyModelsBase`.
+It is extending the [network](https://github.com/EnergyModelsX/EnergyModelsBase.jl/blob/main/examples/network.jl) example of `EnergyModelsBase` to 7 areas.
 
 ## Cite
 
 If you find `EnergyModelsGeography` useful in your work, we kindly request that you cite the following publication:
 
-```@article{boedal_2024,
-  title = {Hydrogen for harvesting the potential of offshore wind: A North Sea case study},
+```bibtex
+@article{boedal_2024,
+  title = {Hydrogen for harvesting the potential of offshore wind: A {N}orth {S}ea case study},
   journal = {Applied Energy},
   volume = {357},
   pages = {122484},
@@ -30,7 +27,7 @@ If you find `EnergyModelsGeography` useful in your work, we kindly request that 
   issn = {0306-2619},
   doi = {https://doi.org/10.1016/j.apenergy.2023.122484},
   url = {https://www.sciencedirect.com/science/article/pii/S0306261923018482},
-  author = {Espen Flo Bødal and Sigmund Eggen Holm and Avinash Subramanian and Goran Durakovic and Dimitri Pinel and Lars Hellemo and Miguel Muñoz Ortiz and Brage Rugstad Knudsen and Julian Straus}
+  author = {Espen Flo B{\o}dal and Sigmund Eggen Holm and Avinash Subramanian and Goran Durakovic and Dimitri Pinel and Lars Hellemo and Miguel Mu{\~n}oz Ortiz and Brage Rugstad Knudsen and Julian Straus}
 }
 ```
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
+EnergyModelsGeography = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"

--- a/docs/src/manual/philosophy.md
+++ b/docs/src/manual/philosophy.md
@@ -11,7 +11,7 @@ The `TransmissionModes` can be static infrastructure such as `PipelineMode` or d
 The latter is in the current stage not yet implemented.
 
 The extension of `EnergyModelsBase` is achieved through calling on the function `create_model` within `EnergyModelsGeography`.
-This corresponds to the 2nd bullet point in the list.
+This corresponds to the 2ⁿᵈ bullet point in the list of *[Extensions to the model](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/manual/philosophy/#sec_phil_ext)*.
 
 Each `Area` is assocoiated with corresponding latitude and longitude coordinates.
 These coordinates can be utilized to calculate the distance between two `Area`s.

--- a/docs/src/manual/quick-start.md
+++ b/docs/src/manual/quick-start.md
@@ -13,9 +13,8 @@
 >     ```
 
 !!! note
-    If you receive the error that one of the packages is not yet registered, you have to add the packages using the GitHub repositories through
+    If you receive the error that `EnergyModelsGeography` is not yet registered, you have to add the package using the GitHub repository through
     ```
-    ] add https://github.com/EnergyModelsX/EnergyModelsBase.jl
     ] add https://github.com/EnergyModelsX/EnergyModelsGeography.jl
     ```
-    Once the packages are registered, this is not required.
+    Once the package is registered, this is not required.

--- a/docs/src/manual/simple-example.md
+++ b/docs/src/manual/simple-example.md
@@ -17,7 +17,7 @@ julia> include(joinpath(exdir, "network.jl"))
 
 ## The code was downloaded with `git clone`
 
-The examples can then be run from the terminal with
+The examples can be run from the terminal with
 
 ```shell script
 ~/../energymodelsgeography.jl/examples $ julia network.jl

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 You have to add the package `EnergyModelsGeography` to your current project in order to run the example.
 It is not necessary to add the other used packages, as the example is instantiating itself.
-How to add packages is explained in the *[Quick start](https://energymodelsx.github.io/EnergyModelsGeography.jl/stable/manual/quick-start/)* of the documentation
+How to add packages is explained in the *[Quick start](https://energymodelsx.github.io/EnergyModelsGeography.jl/stable/manual/quick-start/)* of the documentation.
 
 You can run from the Julia REPL the following code:
 
@@ -14,17 +14,3 @@ julia> exdir = joinpath(pkgdir(EnergyModelsGeography), "examples")
 # Include the code into the Julia REPL to run the examples
 julia> include(joinpath(exdir, "network.jl"))
 ```
-
-> **Note**
->
-> The example is not running yet, as the instantiation would require that the package [`EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl) is registered.
-> It is however possible to run the code directly from a local project in which the packages `TimeStruct`, `EnergyModelsBase`, `EnergyModelsGeography`, `JuMP`, and `HiGHS` are loaded.
-> In this case, you have to comment lines 2-7 out:
-> ```julia
-> # Activate the test-environment, where HiGHS is added as dependency.
-> Pkg.activate(joinpath(@__DIR__, "../test"))
-> # Install the dependencies.
-> Pkg.instantiate()
-> # Add the package EnergyModelsGeography to the environment.
-> Pkg.develop(path=joinpath(@__DIR__, ".."))
-> ```

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -39,6 +39,31 @@ function read_data()
     Power = products[3]
     CO2   = products[4]
 
+    # Variables for the individual entries of the time structure
+    op_duration = 1 # Each operational period has a duration of 2
+    op_number = 24   # There are in total 4 operational periods
+    operational_periods = SimpleTimes(op_number, op_duration)
+
+    # The number of operational periods times the duration of the operational periods, which
+    # can also be extracted using the function `duration` of a `SimpleTimes` structure.
+    # This implies, that a strategic period is 8 times longer than an operational period,
+    # resulting in the values below as "/2h".
+    op_per_strat = duration(operational_periods)
+
+    # Creation of the time structure and global data
+    T = TwoLevel(4, 1, operational_periods; op_per_strat)
+    model = OperationalModel(
+        Dict(
+            CO2 => StrategicProfile([160, 140, 120, 100]),  # CO₂ emission cap in t/24h
+            NG  => FixedProfile(1e6),                       # NG cap in MWh/24h
+        ),
+        Dict(
+            CO2 => FixedProfile(0),                         # CO₂ emission cost in EUR/t
+            NG  => FixedProfile(0),                         # NG emission cost in EUR/t
+        ),
+        CO2,
+    )
+
     # Create input data for the individual areas
     # The input data is based on scaling factors and/or specified demands
     area_ids    = [1, 2, 3, 4, 5, 6, 7]
@@ -122,30 +147,6 @@ function read_data()
                 Transmission(areas[6], areas[7], [SD_OverheadLine_50MW]),
     ]
 
-    # Variables for the individual entries of the time structure
-    op_duration = 1 # Each operational period has a duration of 2
-    op_number = 24   # There are in total 4 operational periods
-    operational_periods = SimpleTimes(op_number, op_duration)
-
-    # The number of operational periods times the duration of the operational periods, which
-    # can also be extracted using the function `duration` which corresponds to the total
-    # duration of the operational periods in a `SimpleTimes` structure
-    op_per_strat = duration(operational_periods)
-
-    # Creation of the time structure and global data
-    T = TwoLevel(4, 1, operational_periods; op_per_strat)
-    model = OperationalModel(
-        Dict(
-            CO2 => StrategicProfile([160, 140, 120, 100]),  # CO2 emission cap in t/24h
-            NG  => FixedProfile(1e6),                        # NG cap in MWh/24h
-        ),
-        Dict(
-            CO2 => FixedProfile(0),                         # CO2 emission cost in EUR/t
-            NG  => FixedProfile(0),                         # NG emission cost in EUR/t
-        ),
-        CO2,
-    )
-
     # WIP data structure
     case = Dict(
                 :areas          => Array{Area}(areas),
@@ -191,7 +192,7 @@ function get_sub_system_data(
     end
 
     # Create the individual test nodes, corresponding to a system with an electricity demand/sink,
-    # coal and nautral gas sources, coal and natural gas (with CCS) power plants and CO2 storage.
+    # coal and nautral gas sources, coal and natural gas (with CCS) power plants and CO₂ storage.
     j=(i-1)*100
     nodes = [
             GeoAvailability(j+1, products),
@@ -220,7 +221,7 @@ function get_sub_system_data(
                 Dict(Power => 1, CO2 => 1), # Output from the node with output ratio
                 # Line above: CO2 is required as output for variable definition, but the
                 # value does not matter
-                [CaptureEnergyEmissions(0.9)], # Additonal data for emissions and CO2 capture
+                [CaptureEnergyEmissions(0.9)], # Additonal data for emissions and CO₂ capture
             ),
             RefNetworkNode(
                 j+5,                        # Node id
@@ -233,15 +234,15 @@ function get_sub_system_data(
             ),
             RefStorage(
                 j+6,                        # Node id
-                FixedProfile(20),           # Rate capacity in MW
-                FixedProfile(600),          # Storage capacity in MWh
-                FixedProfile(9.1),          # Storage variable OPEX for the rate in EUR/MW
-                FixedProfile(0),            # Storage fixed OPEX for the rate in EUR/24h
+                FixedProfile(20),           # Rate capacity in t/h
+                FixedProfile(600),          # Storage capacity in t
+                FixedProfile(9.1),          # Storage variable OPEX for the rate in EUR/t
+                FixedProfile(0),            # Storage fixed OPEX for the rate in EUR/(t/h 24h)
                 CO2,                        # Stored resource
                 Dict(CO2 => 1, Power => 0.02), # Input resource with input ratio
                 # Line above: This implies that storing CO2 requires Power
                 Dict(CO2 => 1),             # Output from the node with output ratio
-                # In practice, for CO2 storage, this is never used.
+                # In practice, for CO₂ storage, this is never used.
                 Array{Data}([]),            # Potential additional data
             ),
             RefSink(

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -124,15 +124,15 @@ function read_data()
     opex_var = FixedProfile(0.05)   # Variable OPEX in EUR/MWh
     opex_fix = FixedProfile(0.05)   # Fixed OPEX in EUR/24h
 
-    OB_OverheadLine_50MW   = RefStatic("OB_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix,  2, [])
-    OT_OverheadLine_50MW   = RefStatic("OT_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2, [])
-    OK_OverheadLine_50MW   = RefStatic("OK_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2, [])
-    BT_OverheadLine_50MW   = RefStatic("BT_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2, [])
-    BTN_LNG_Ship_100MW     = RefDynamic("BTN_LNG_100", NG, cap_lng, loss, opex_var, opex_fix, 1, [])
-    BK_OverheadLine_50MW   = RefStatic("BK_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2, [])
-    TTN_OverheadLine_50MW  = RefStatic("TTN_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2, [])
-    KS_OverheadLine_50MW  = RefStatic("KS_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2, [])
-    SD_OverheadLine_50MW  = RefStatic("SD_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2, [])
+    OB_OverheadLine_50MW   = RefStatic("OB_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix,  2)
+    OT_OverheadLine_50MW   = RefStatic("OT_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2)
+    OK_OverheadLine_50MW   = RefStatic("OK_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2)
+    BT_OverheadLine_50MW   = RefStatic("BT_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2)
+    BTN_LNG_Ship_100MW     = RefDynamic("BTN_LNG_100", NG, cap_lng, loss, opex_var, opex_fix, 1)
+    BK_OverheadLine_50MW   = RefStatic("BK_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2)
+    TTN_OverheadLine_50MW  = RefStatic("TTN_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2)
+    KS_OverheadLine_50MW  = RefStatic("KS_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2)
+    SD_OverheadLine_50MW  = RefStatic("SD_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2)
 
     # Create the different transmission corridors between the individual areas
     transmission = [
@@ -202,7 +202,6 @@ function get_sub_system_data(
                 FixedProfile(30*mc_scale),  # Variable OPEX in EUR/MW
                 FixedProfile(0),            # Fixed OPEX in EUR/24h
                 Dict(NG => 1),              # Output from the Node, in this gase, NG
-                [],                         # Potential additional data
             ),
             RefSource(
                 j+3,                        # Node id
@@ -210,7 +209,6 @@ function get_sub_system_data(
                 FixedProfile(9*mc_scale),   # Variable OPEX in EUR/MWh
                 FixedProfile(0),            # Fixed OPEX in EUR/24h
                 Dict(Coal => 1),            # Output from the Node, in this gase, coal
-                [],                         # Potential additional data
             ),
             RefNetworkNode(
                 j+4,                        # Node id
@@ -243,7 +241,7 @@ function get_sub_system_data(
                 # Line above: This implies that storing CO2 requires Power
                 Dict(CO2 => 1),             # Output from the node with output ratio
                 # In practice, for CO₂ storage, this is never used.
-                Array{Data}([]),            # Potential additional data
+                Data[]
             ),
             RefSink(
                 j+7,                        # Node id

--- a/src/legacy_constructors.jl
+++ b/src/legacy_constructors.jl
@@ -1,6 +1,6 @@
 """
 Legacy constructor for a `GeoAvailability`. This version will be discontinued
-    in the near future and replaced with the application of Arrays instead of Dictionaries.
+in the near future and replaced with the application of Arrays instead of Dictionaries.
 """
 function GeoAvailability(
     id,

--- a/src/structures_area.jl
+++ b/src/structures_area.jl
@@ -36,8 +36,10 @@ coupled with multiple other areas and the total export capacity should be restri
 - **`name`** is the name of the area.\n
 - **`lon::Real`** is the longitudinal position of the area.\n
 - **`lat::Real`** is the latitudinal position of the area.\n
-- **`node::Availability`** is the `Availability` node routing different resources within an area.
-- **`limit::Dict{EMB.Resource, TimeProfile}`** is the amount of a resource that can be exchanged with other areas
+- **`node::Availability`** is the `Availability` node routing different resources within \
+an area.
+- **`limit::Dict{<:EMB.Resource, <:TimeProfile}`** is the amount of a resource that can \
+be exchanged with other areas
 """
 struct LimitedExchangeArea <: Area
     id
@@ -45,7 +47,7 @@ struct LimitedExchangeArea <: Area
     lon::Real
     lat::Real
     node::EMB.Availability
-    limit::Dict{EMB.Resource, TimeProfile}
+    limit::Dict{<:EMB.Resource, <:TimeProfile}
 end
 
 """

--- a/src/structures_area.jl
+++ b/src/structures_area.jl
@@ -57,9 +57,9 @@ A `GeoAvailability` is required if transmission should be included between indiv
 
 # Fields
 - **`id`** is the name/identifier of the node.\n
-- **`input::Array{<:Resource}`** are the input `Resource`s with conversion value `Real`.
+- **`input::Array{<:Resource}`** are the input `Resource`s with conversion value `Real`. \
 The latter are not relevant but included for consistency with other formulations.\n
-- **`output::Array{<:Resource}`** are the generated `Resource`s with conversion value `Real`.
+- **`output::Array{<:Resource}`** are the generated `Resource`s with conversion value `Real`. \
 The latter are not relevant but included for consistency with other formulations.\n
 
 """

--- a/src/structures_mode.jl
+++ b/src/structures_mode.jl
@@ -16,7 +16,8 @@ transmission, modelled as a ratio.\n
 - **`opex_fixed::TimeProfile`** is the fixed operational costs per installed capacity.\n
 - **`directions`** is the number of directions the resource can be transported, \
 1 is unidirectional (A->B) or 2 is bidirectional (A<->B).\n
-- **`data::Dict{String, Data}`** is the additional data (e.g. for investments).
+- **`data::Vector{Data}`** is the additional data (e.g. for investments). The field \
+`data` is conditional through usage of a constructor.
 """
 struct RefDynamic <: TransmissionMode # E.g. Trucks, ships etc.
     id::String
@@ -26,8 +27,18 @@ struct RefDynamic <: TransmissionMode # E.g. Trucks, ships etc.
     opex_var::TimeProfile
     opex_fixed::TimeProfile
     directions::Int # 1: Unidirectional or 2: Bidirectional
-    #formulation::EMB.Formulation # linear/non-linear etc.
-    data::Array{Data}
+    data::Vector{Data}
+end
+function RefDynamic(
+        id::String,
+        resource::EMB.Resource,
+        trans_cap::TimeProfile,
+        trans_loss::TimeProfile,
+        opex_var::TimeProfile,
+        opex_fixed::TimeProfile,
+        directions::Int,
+    )
+    return RefDynamic(id, resource, trans_cap, trans_loss, opex_var, opex_fixed, directions, Data[])
 end
 
 """ A reference static `TransmissionMode`.
@@ -44,7 +55,8 @@ modelled as a ratio.\n
 - **`opex_fixed::TimeProfile`** is the fixed operational costs per installed capacity.\n
 - **`directions`** is the number of directions the resource can be transported, \
 1 is unidirectional (A->B) or 2 is bidirectional (A<->B).\n
-- **`data::Dict{String, Data}`** is the additional data (e.g. for investments).
+- **`data::Vector{Data}`** is the additional data (e.g. for investments). The field \
+`data` is conditional through usage of a constructor.
 """
 struct RefStatic <: TransmissionMode # E.g. overhead power lines, pipelines etc.
     id::String
@@ -54,8 +66,18 @@ struct RefStatic <: TransmissionMode # E.g. overhead power lines, pipelines etc.
     opex_var::TimeProfile
     opex_fixed::TimeProfile
     directions::Int
-    #formulation::EMB.Formulation
-    data::Array{Data}
+    data::Vector{Data}
+end
+function RefStatic(
+        id::String,
+        resource::EMB.Resource,
+        trans_cap::TimeProfile,
+        trans_loss::TimeProfile,
+        opex_var::TimeProfile,
+        opex_fixed::TimeProfile,
+        directions::Int,
+    )
+    return RefStatic(id, resource, trans_cap, trans_loss, opex_var, opex_fixed, directions, Data[])
 end
 
 
@@ -87,7 +109,7 @@ consumed, as a ratio of the volume of the resource going into the inlet. I.e.:
 - **`opex_var::TimeProfile`** is the variational operational costs per energy unit transported.\n
 - **`opex_fixed::TimeProfile`** is the fixed operational costs per installed capacity.\n
 - **`directions`** specifies that the pipeline is Unidirectional (1) by default.\n
-- **`data::Dict{String, Data}`** is the additional data (e.g. for investments).
+- **`data::Vector{Data}`** is the additional data (e.g. for investments).
 """
 Base.@kwdef struct PipeSimple <: PipeMode
     id::String
@@ -102,9 +124,8 @@ Base.@kwdef struct PipeSimple <: PipeMode
     opex_fixed::TimeProfile
     # TODO remove below field? Should not be relevant for fluid pipeline.
     directions::Int = 1     # 1: Unidirectional only for pipeline
-    data::Array{Data}
+    data::Vector{Data} = Data[]
 end
-
 
 """
     PipeLinepackSimple <: TransmissionMode
@@ -113,7 +134,7 @@ Pipeline model with linepacking implemented as simple storage function.
 # Fields (additional to `PipeSimple`)
 - **`energy_share::Float64`**  - is the storage energy capacity relative to pipeline capacity.\n
 - **`Level_share_init::Float64`**  - is the initial storage level. \n
-- **`data::Dict{String, Data}`** is the additional data (e.g. for investments).
+- **`data::Vector{Data}`** is the additional data (e.g. for investments).
 """
 Base.@kwdef struct PipeLinepackSimple <: PipeMode
     id::String
@@ -127,17 +148,17 @@ Base.@kwdef struct PipeLinepackSimple <: PipeMode
     opex_fixed::TimeProfile
     energy_share::Float64 # Storage energy capacity relative to pipeline capacity
     directions::Int = 1     # 1: Unidirectional only for pipeline
-    data::Array{Data}
+    data::Vector{Data} = Data[]
 end
 
 """
-    modes_sub(ℳ, string::String)
+    modes_sub(ℳ::Vector{<:TransmissionMode}, string::String)
 
 Returns all transmission modes that include in the name the `string`.
 """
-function modes_sub(ℳ, string::String)
+function modes_sub(ℳ::Vector{<:TransmissionMode}, string::String)
 
-    sub_modes = Array{TransmissionMode}([])
+    sub_modes = TransmissionMode[]
     for tm ∈ ℳ
         if isequal(string, tm.id)
             append!(sub_modes, [tm])
@@ -147,14 +168,14 @@ function modes_sub(ℳ, string::String)
     return sub_modes
 end
 """
-    modes_sub(ℳ, string_array::Array{String})
+    modes_sub(ℳ::Vector{<:TransmissionMode}, string_array::Array{String})
 
 Returns all transmission modes that include in the name all entries of
 the array `string_array`.
 """
-function modes_sub(ℳ, string_array::Array{String})
+function modes_sub(ℳ::Vector{<:TransmissionMode}, string_array::Array{String})
 
-    sub_modes = Array{TransmissionMode}([])
+    sub_modes = TransmissionMode[]
     for tm ∈ ℳ
         if all(isequal(string, tm.id) for string ∈ string_array)
             append!(sub_modes, [tm])
@@ -232,11 +253,11 @@ Returns the variable OPEX of transmission mode `tm` as `TimeProfile`.
 """
 EMB.opex_fixed(tm::TransmissionMode) = tm.opex_fixed
 """
-    opex_fixed(tm::TransmissionMode, t)
+    opex_fixed(tm::TransmissionMode, t_inv)
 
-Returns the variable OPEX of transmission mode `tm` at time period `t`.
+Returns the variable OPEX of transmission mode `tm` at strategic period `t_inv`.
 """
-EMB.opex_fixed(tm::TransmissionMode, t) = tm.opex_fixed[t]
+EMB.opex_fixed(tm::TransmissionMode, t_inv) = tm.opex_fixed[t_inv]
 
 """
     loss(tm::TransmissionMode)

--- a/src/structures_mode.jl
+++ b/src/structures_mode.jl
@@ -10,10 +10,12 @@ Generic representation of dynamic transmission modes, using for example truck, s
 - **`id::String`** is the name/identifyer of the transmission mode.\n
 - **`resource::Resource`** is the resource that is transported.\n
 - **`trans_cap::TimeProfile`** is the capacity of the transmission mode.\n
-- **`trans_loss::TimeProfile`** is the loss of the transported resource during transmission, modelled as a ratio.\n
+- **`trans_loss::TimeProfile`** is the loss of the transported resource during \
+transmission, modelled as a ratio.\n
 - **`opex_var::TimeProfile`** is the variational operational costs per energy unit transported.\n
 - **`opex_fixed::TimeProfile`** is the fixed operational costs per installed capacity.\n
-- **`directions`** is the number of directions the resource can be transported, 1 is unidirectional (A->B) or 2 is bidirectional (A<->B).\n
+- **`directions`** is the number of directions the resource can be transported, \
+1 is unidirectional (A->B) or 2 is bidirectional (A<->B).\n
 - **`data::Dict{String, Data}`** is the additional data (e.g. for investments).
 """
 struct RefDynamic <: TransmissionMode # E.g. Trucks, ships etc.
@@ -36,10 +38,12 @@ Generic representation of static transmission modes, such as overhead power line
 - **`id::String`** is the name/identifyer of the transmission mode.\n
 - **`resource::Resource`** is the resource that is transported.\n
 - **`trans_cap::Real`** is the capacity of the transmission mode.\n
-- **`trans_loss::Real`** is the loss of the transported resource during transmission, modelled as a ratio.\n
+- **`trans_loss::Real`** is the loss of the transported resource during transmission, \
+modelled as a ratio.\n
 - **`opex_var::TimeProfile`** is the variational operational costs per energy unit transported.\n
 - **`opex_fixed::TimeProfile`** is the fixed operational costs per installed capacity.\n
-- **`directions`** is the number of directions the resource can be transported, 1 is unidirectional (A->B) or 2 is bidirectional (A<->B).\n
+- **`directions`** is the number of directions the resource can be transported, \
+1 is unidirectional (A->B) or 2 is bidirectional (A<->B).\n
 - **`data::Dict{String, Data}`** is the additional data (e.g. for investments).
 """
 struct RefStatic <: TransmissionMode # E.g. overhead power lines, pipelines etc.
@@ -74,8 +78,8 @@ the pipeline.
 - **`inlet::Resource`** is the `Resource` going into transmission.\n
 - **`outlet::Resource`** is the `Resource` going out of the outlet of the transmission.\n
 - **`consuming::Resource`** is the `Resource` the transmission consumes by operating.\n
-- **`consumption_rate::Real`** the rate of which the resource `Pipeline.consuming` is consumed, as
-    a ratio of the volume of the resource going into the inlet. I.e.:
+- **`consumption_rate::Real`** the rate of which the resource `Pipeline.consuming` is \
+consumed, as a ratio of the volume of the resource going into the inlet. I.e.:
 
         `consumption_rate` = consumed volume / inlet volume (per operational period)\n
 - **`trans_cap::Real`** is the capacity of the transmission mode.\n

--- a/src/structures_transmission.jl
+++ b/src/structures_transmission.jl
@@ -5,12 +5,12 @@ A geographic corridor where `TransmissionModes` are used to transport resources.
 # Fields
 - **`from::Area`** is the area resources are transported from.\n
 - **`to::Area`** is the area resources are transported to.\n
-- **`modes::Array{TransmissionMode}`** are the transmission modes that are available.\n
+- **`modes::Vector{<:Transmission}`** are the transmission modes that are available.\n
 """
 struct Transmission
     from::Area
     to::Area
-    modes::Array{TransmissionMode}
+    modes::Vector{<:TransmissionMode}
 end
 Base.show(io::IO, t::Transmission) = print(io, "$(t.from)-$(t.to)")
 
@@ -27,7 +27,7 @@ modes(l::Transmission) = l.modes
 Return an array of all transmission modes present in the different transmission corridors.
 """
 function modes(ℒ::Vector{<:Transmission})
-    tmp = Vector{TransmissionMode}()
+    tmp = TransmissionMode[]
     for l ∈ ℒ
         append!(tmp, modes(l))
     end

--- a/test/test_geo_bidirectional.jl
+++ b/test/test_geo_bidirectional.jl
@@ -27,14 +27,14 @@ function bidirectional_case()
     nodes = [
             EMG.GeoAvailability(1, products),
             RefSource(2, FixedProfile(200), OperationalProfile([10 100]), FixedProfile(0), Dict(NG => 1)),
-            RefNetworkNode(3, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1)),
+            RefNetworkNode(3, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1), Data[]),
             RefSink(4, OperationalProfile(demand),
                 Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
                 Dict(Power => 1)),
 
             EMG.GeoAvailability(5, products),
             RefSource(6, FixedProfile(200), OperationalProfile([100 10]), FixedProfile(0), Dict(NG => 1)),
-            RefNetworkNode(7, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1)),
+            RefNetworkNode(7, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1), Data[]),
             RefSink(8, OperationalProfile(demand),
                 Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
                 Dict(Power => 1)),

--- a/test/test_geo_bidirectional.jl
+++ b/test/test_geo_bidirectional.jl
@@ -26,15 +26,15 @@ function bidirectional_case()
     demand = [40 40]
     nodes = [
             EMG.GeoAvailability(1, products),
-            RefSource(2, FixedProfile(200), OperationalProfile([10 100]), FixedProfile(0), Dict(NG => 1), []),
-            RefNetworkNode(3, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1), []),
+            RefSource(2, FixedProfile(200), OperationalProfile([10 100]), FixedProfile(0), Dict(NG => 1)),
+            RefNetworkNode(3, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1)),
             RefSink(4, OperationalProfile(demand),
                 Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
                 Dict(Power => 1)),
 
             EMG.GeoAvailability(5, products),
-            RefSource(6, FixedProfile(200), OperationalProfile([100 10]), FixedProfile(0), Dict(NG => 1), []),
-            RefNetworkNode(7, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1), []),
+            RefSource(6, FixedProfile(200), OperationalProfile([100 10]), FixedProfile(0), Dict(NG => 1)),
+            RefNetworkNode(7, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1)),
             RefSink(8, OperationalProfile(demand),
                 Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
                 Dict(Power => 1)),
@@ -66,7 +66,6 @@ function bidirectional_case()
         FixedProfile(0.05),
         FixedProfile(0.05),
         2,
-        [],
     )
     transmission = [Transmission(areas[1], areas[2], [transmission_line])]
 

--- a/test/test_geo_opex.jl
+++ b/test/test_geo_opex.jl
@@ -39,7 +39,7 @@ end
     t_opex_fixed = FixedProfile(0.0)
 
     # increase opex var, but not enough to change the results
-    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2, [])
+    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
 
     # Create and solve the model
     m = optimize(case, modeltype)
@@ -55,7 +55,7 @@ end
 
     # Cange transmission mode parameters
     t_opex_var = FixedProfile((fuel_opex_diff - marginal_diff) * gen_fuel_coeff)
-    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2, [])
+    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
 
     m = solve_and_check(case, modeltype, "trans_cap", "trans_cap")
 
@@ -63,7 +63,7 @@ end
 
     # increase opex var, so high that transmission in not profitable
     t_opex_var = FixedProfile((fuel_opex_diff + marginal_diff) * gen_fuel_coeff)
-    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2, [])
+    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
 
     m = solve_and_check(case, modeltype, 0.0, 0.0)
 
@@ -72,7 +72,7 @@ end
     # Cange transmission mode parameters
     t_opex_var = FixedProfile(0.0) # no opex var
     t_opex_fixed = FixedProfile(1e3) # high opex fixed
-    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2, [])
+    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
 
     m = solve_and_check(case, modeltype, "trans_cap", "trans_cap")
 
@@ -83,7 +83,7 @@ end
 
     # Cange transmission mode parameters
     t_opex_var = FixedProfile((fuel_opex_diff - marginal_diff) * gen_fuel_coeff)
-    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 1, [])
+    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 1)
 
     m = solve_and_check(case, modeltype, "trans_cap", 0.0)
 
@@ -91,9 +91,8 @@ end
 
     # increase opex var, so high that transmission in not profitable
     t_opex_var = FixedProfile((fuel_opex_diff + marginal_diff) * gen_fuel_coeff)
-    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 1, [])
+    case[:transmission][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 1)
 
     m = solve_and_check(case, modeltype, 0.0, 0.0)
-
 
 end

--- a/test/test_geo_unidirectional.jl
+++ b/test/test_geo_unidirectional.jl
@@ -8,7 +8,7 @@ function small_graph(source=nothing, sink=nothing)
     # Creation of the source and sink module as well as the arrays used for nodes and links
     if isnothing(source)
         source = RefSource("-src", FixedProfile(25), FixedProfile(10),
-            FixedProfile(5), Dict(Power => 1), [])
+            FixedProfile(5), Dict(Power => 1))
     end
 
     if isnothing(sink)
@@ -33,7 +33,6 @@ function small_graph(source=nothing, sink=nothing)
         FixedProfile(0.1),
         FixedProfile(0.1),
         1,
-        [],
     )
     transmission_line_2 = EMG.RefStatic(
         "transline2",
@@ -43,10 +42,9 @@ function small_graph(source=nothing, sink=nothing)
         FixedProfile(0.1),
         FixedProfile(0.1),
         1,
-        [],
     )
-    transmissions = [Transmission(areas[1], areas[2], [transmission_line_1]),
-                     Transmission(areas[2], areas[1], [transmission_line_2])]
+    transmissions = [Transmission(areas[1], areas[2], Vector{TransmissionMode}([transmission_line_1])),
+                     Transmission(areas[2], areas[1], Vector{TransmissionMode}([transmission_line_2]))]
 
     # Creation of the time structure and the used global data
     T = TwoLevel(4, 1, SimpleTimes(4, 1))
@@ -67,8 +65,6 @@ function small_graph(source=nothing, sink=nothing)
                 )
     return case, modeltype
 end
-
-
 
 function transmission_tests(m, case)
     # Extraction of relevant data from the model
@@ -141,9 +137,9 @@ end
                                         prev_tm.opex_var,
                                         prev_tm.opex_fixed,
                                         directions(prev_tm),
-                                        [])
-            @assert directions(prev_tm) == 1 "The Dircetion mode should be
-                                                 unidirectional."
+                                        Data[]
+                                        )
+            @assert directions(prev_tm) == 1 "The Direction mode should be unidirectional."
             modes(transmission)[i] = pipeline
         end
     end

--- a/test/test_simplelinepack.jl
+++ b/test/test_simplelinepack.jl
@@ -46,7 +46,7 @@ function small_graph_linepack()
         FixedProfile(0.05),   # Opex fixed
         0.1,                  # Storage capacity
         1,
-        []
+        Data[]
         )
 
     transmissions = [Transmission(areas[1], areas[2], [pipeline])]

--- a/test/test_simplepipe.jl
+++ b/test/test_simplepipe.jl
@@ -22,7 +22,7 @@ function small_graph_co2_1()
 
     # Creation of the source and sink module as well as the arrays used for nodes and links
     source = RefSource("-src", FixedProfile(25), FixedProfile(10),
-        FixedProfile(5), Dict(CO2_150 => 1, Power => 1), [])
+        FixedProfile(5), Dict(CO2_150 => 1, Power => 1))
     el_sink = RefSink("-el-sink", FixedProfile(0),
         Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
         Dict(Power => 1))
@@ -41,7 +41,9 @@ function small_graph_co2_1()
     areas = [RefArea(1, "Factory", 10.751, 59.921, nodes[1]),
              RefArea(2, "North Sea", 10.398, 63.4366, nodes[2])]
 
-    pipeline = PipeSimple("pipeline", CO2_150, CO2_200, Power, FixedProfile(0.1), FixedProfile(100), FixedProfile(0.05), FixedProfile(0.05), FixedProfile(0.05), 1, [])
+    pipeline = PipeSimple(
+        "pipeline", CO2_150, CO2_200, Power, FixedProfile(0.1), FixedProfile(100),
+        FixedProfile(0.05), FixedProfile(0.05), FixedProfile(0.05), 1, Data[])
 
     transmissions = [Transmission(areas[1], areas[2], [pipeline])]
 


### PR DESCRIPTION
1. The GitHub CI is based on the one we used in `EnergyModelsBase`.
2. The documentation and README was updated to account for the registration of `EnergyModelsBase` and remove sections that were not required due to the registration of `EnergyModelsBase`. In addition, minor errors were fixed.
3. The restrictions on the introduced types were increased to avoid any errors. This includes as well the incorporation of constructors.