### PR TITLE
[docs] fix link to examples directory

### DIFF
--- a/docs/src/manual/simple-example.md
+++ b/docs/src/manual/simple-example.md
@@ -1,6 +1,6 @@
 # Examples
 
-For the content of the example, see the *[examples](https://gitlab.sintef.no/clean_export/energymodelsgeography.jl/-/tree/main/examples)* directory in the project repository.
+For the content of the example, see the *[examples](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/tree/main/examples)* directory in the project repository.
 
 ## The package is installed with `] add`
 


### PR DESCRIPTION
You might want to check for other `gitlab.sintef.no` links in the various packages. 