### PR TITLE
Added a contribution section

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Unversioned
+
+* Provided a contribution section in the documentation.
+
 ## Version 0.8.3 (2024-03-21)
 
 * Fixed a bug regarding accessing the field `limit` of a `LimitedExchangeArea`.
@@ -29,14 +33,14 @@ These changes are mainly:
 
 ## Version 0.7.1 (2023-06-16)
 
-* Updated the documentation based on the new format
+* Updated the documentation based on the new format.
 
 ## Version 0.7.0 (2023-06-06)
 
-### Switch to TimeStruct.jl
+### Switch to TimeStruct
 
-* Switched the time structure representation to [TimeStruct.jl](https://github.com/sintefore/TimeStruct.jl)
-* TimeStruct.jl is implemented with only the basis features that were available in TimesStructures.jl. This implies that neither operational nor strategic uncertainty is included in the model.
+* Switched the time structure representation to [`TimeStruct`](https://github.com/sintefore/TimeStruct.jl).
+* `TimeStruct` is implemented with only the basis features that were available in `TimeStructures`. This implies that neither operational nor strategic uncertainty is included in the model.
 
 ## Version 0.6.1 (2023-06-02)
 
@@ -44,20 +48,20 @@ These changes are mainly:
 
 ## Version 0.6.0 (2023-05-30)
 
-* Changed the structure in which the extra field `Data` is included in the nodes
-* It is changed from `Dict{String, Data}` to `Array{data}`
+* Changed the structure in which the extra field `Data` is included in the nodes.
+* It is changed from `Dict{String, Data}` to `Array{data}`.
 
 ## Version 0.5.2 (2023-05-16)
 
-* Bugfix in the example which lead to a trivial solution in which no energy has to be converted
+* Bugfix in the example which lead to a trivial solution in which no energy has to be converted.
 
 ## Version 0.5.1 (2023-04-30)
 
 ### Multiple smaller updates
 
-* Moved the example in `user_interface.jl` into an example folder
-* Introduced checks that can be utlized to check transmission related data
-* Fixed a bug for `LimitedExchangeArea` that utilized wrong values
+* Moved the example in `user_interface.jl` into an example folder.
+* Introduced checks that can be utlized to check transmission related data.
+* Fixed a bug for `LimitedExchangeArea` that utilized wrong values.
 
 ## Version 0.5.0 (2023-04-27)
 
@@ -82,16 +86,16 @@ These changes are mainly:
 ### Additional changes
 
 * Change of variable generation for individual transmission modes: Variable generation _via_ the function `variables_trans_mode(s)` is adjusted to follow the concept introduced in `EnergyModelsBase`.
-* Move of the field `Data` from `Transmission` to `TransmissionMode`. This is required for the later application of dispatching in `EnergyModelsInvestments`
+* Move of the field `Data` from `Transmission` to `TransmissionMode`. This is required for the later application of dispatching in `EnergyModelsInvestments`.
 
 ## Version 0.3.1 (2023-02-16)
 
 ### Introduction of linepacking
 
-* Redefinition of `PipelineMode` as abstract type `PipeMode` and introduction of `PipeSimple` as a composite type corresponding to the previous `PipelineMode`
-* Introduction of a simple linepacking implementation _via_ the type `PipeLinepackSimple
-* Change of `Area` to `abstract type` to be able to dispatch on areas
-* Rewriting how functions for variable generation are called for easier introduction of variables for different `TransmissionMode`s
+* Redefinition of `PipelineMode` as abstract type `PipeMode` and introduction of `PipeSimple` as a composite type corresponding to the previous `PipelineMode`.
+* Introduction of a simple linepacking implementation _via_ the type `PipeLinepackSimple.
+* Change of `Area` to `abstract type` to be able to dispatch on areas.
+* Rewriting how functions for variable generation are called for easier introduction of variables for different `TransmissionMode`s.
 
 ## Version 0.3.0 (2023-02-02)
 
@@ -99,29 +103,29 @@ These changes are mainly:
 
 Adjustment to version 0.3.0, namely:
 
-* The removal of emissions from `Node` type definition that do not require them in all tests
-* Removal of the type `GlobalData` and replacement with fields in the type `OperationalModel` in all tests
+* The removal of emissions from `Node` type definition that do not require them in all tests.
+* Removal of the type `GlobalData` and replacement with fields in the type `OperationalModel` in all tests.
 
 ## Version 0.2.2 (2022-12-12)
 
 ### Internal release
 
-* Updated Readme
-* Renamed with common prefix
+* Updated Readme.
+* Renamed with common prefix.
 
 ## Version 0.2.1 (2021-09-07)
 
 ### Changes in naming
 
-* Major changes in both variable and parameter naming, check the commit message for an overview
-* Introduction of bidrectional flow in transmission lines
+* Major changes in both variable and parameter naming, check the commit message for an overview.
+* Introduction of bidrectional flow in transmission lines.
 
 ## Version 0.2.0 (2021-08-02)
 
-* Defined structures for `Area`s, `Transmission` corridors and `TransmissionMode`s
-* Overloading of the default availability node balance to allow for export and import
-* Added examples of plotting in maps
+* Defined structures for `Area`s, `Transmission` corridors and `TransmissionMode`s.
+* Overloading of the default availability node balance to allow for export and import.
+* Added examples of plotting in maps.
 
 ## Version 0.1.0 (2021-04-19)
 
-* Initial (skeleton) version
+* Initial (skeleton) version.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,7 +17,7 @@ cp("NEWS.md", news; force=true)
 
 makedocs(
     modules = [EnergyModelsGeography],
-    sitename = "EnergyModelsGeography.jl",
+    sitename = "EnergyModelsGeography",
     format = Documenter.HTML(
         prettyurls = get(ENV, "CI", "false") == "true",
         edit_link = "main",
@@ -33,6 +33,9 @@ makedocs(
             "TransmissionMode structure" => "manual/transmission-mode.md",
             "Example" => "manual/simple-example.md",
             "Release notes" => "manual/NEWS.md",
+        ],
+        "How to" => Any[
+            "Contribute to EnergyModelsGeography" => "how-to/contribute.md",
         ],
         "Library" => Any[
             "Public" => "library/public.md",

--- a/docs/src/how-to/contribute.md
+++ b/docs/src/how-to/contribute.md
@@ -1,0 +1,52 @@
+# Contribute to EnergyModelsGeography
+
+Contributing to `EnergyModelsGeography` can be achieved in several different ways.
+
+## Creating new extensions
+
+The main focus of `EnergyModelsGeography` is to provide [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/) with geographical representation using the concepts of [`Area`](@ref)s, [`Transmission`](@ref) corridors, or [`TransmissionMode`](@ref)s.
+Hence, a first approach to contributing to `EnergyModelsGeography` is to create a new package with, _e.g._, the introduction of new `Area`, `Transmission`, or `TransmissionMode` descriptions.
+These descriptions can, _e.g._, include constraints for an `Area` or provide the model with new mathematical formulations for energy transmissions.
+
+!!! note
+    We are currently working on guidelines for the best approach for `EnergyModelsGeography`, similar to the section [_Extensions to the model_](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/manual/philosophy/#sec_phil_ext) in `EnergyModelsBase`.
+    This section will provide you eventually with additional information regarding to how you can develop new `Area`, `Transmission`, or `TransmissionMode` descriptions.
+
+## File a bug report
+
+Another approach to contributing to `EnergyModelsGeography` is through filing a bug report as an _[issue](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/issues/new)_ when unexpected behaviour is occuring.
+
+When filing a bug report, please follow the following guidelines:
+
+1. Be certain that the bug is a bug and originating in `EnergyModelsGeography`:
+    - If the problem is within the results of the optimization problem, please check first that the nodes are correctly linked with each other.
+      Frequently, missing links (or wrongly defined links) restrict the transport of energy/mass.
+      If you are certain that all links are set correctly, it is most likely a bug in `EnergyModelsGeography` and should be reported.
+    - If you observe no transfer of mass between geographical regions, please check first that you use a `GeoAvailability` node as the description is different from a `GenAvailability` node.
+      In addition, please check that the `Transmission` corridors and `TransmissionMode`s are set correctly as well as there is a demand or suppy in both areas of the transported `Resource`.
+    - If the problem occurs in model construction, it is most likely a bug in either `EnergyModelsBase` or `EnergyModelsGeography` and should be reported in the respective package.
+      The error message of Julia should provide you with the failing function and whether the failing function is located in `EnergyModelsBase` or `EnergyModelsGeography`.
+      It can occur, that the last shown failing function is within `JuMP` or `MathOptInterface`.
+      In this case, it is best to trace the error to the last called `EnergyModelsBase` or `EnergyModelsGeography` function.
+    - If the problem is only appearing for specific solvers, it is most likely not a bug in `EnergyModelsGeography`, but instead a problem of the solver wrapper for `MathOptInterface`.
+      In this case, please contact the developers of the corresponding solver wrapper.
+2. Label the issue as bug, and
+3. Provide a minimum working example of a case in which the bug occurs.
+
+!!! note
+    We are aware that certain design choices within `EnergyModelsGeography` can lead to method ambiguities.
+    Our aim is to extend the documentation to improve the description on how to best extend the base functionality as well as which caveats can occur.
+
+    In order to improve the code, we welcome any reports of potential method ambiguities to help us improving the structure of the framework.
+
+## Feature requests
+
+Although `EnergyModelsGeography` was designed with the aim of flexibility, it sometimes still requires additional features to account for potential extensions.
+Feature requests for `EnergyModelsGeography` should follow the guidelines developed for [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/how-to/contribute/).
+
+!!! note
+    `EnergyModelsGeography` should not include everything.
+
+    The aim of the framework is to be lightweight and extensible by the user.
+    Hence, feature requests should only include basic requirements for the core structure, and not, _e.g._, the description of new `Area`s description.
+    These should be developed outside of `EnergyModelsGeography`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,10 @@
-# EnergyModelsGeography.jl
+# EnergyModelsGeography
 
 ```@docs
 EnergyModelsGeography
 ```
 
-The Julia package extends [`EnergyModelsBase.jl`](https://energymodelsx.github.io/EnergyModelsBase.jl/) with functionality to set up an energy system consisting of several separate regions, with transmissions between.
+The Julia package extends [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/) with functionality to set up an energy system consisting of several separate regions, with transmissions between.
 
 The extension focuses on overriding the function `EMB.create_model` to add additional types, variables, and constraints to the model.
 
@@ -18,6 +18,14 @@ Pages = [
     "manual/constraint-functions.md",
     "manual/transmission-mode.md",
     "manual/simple-example.md"
+]
+```
+
+## How to guides
+
+```@contents
+Pages = [
+    "how-to/contribute.md",
 ]
 ```
 

--- a/docs/src/manual/quick-start.md
+++ b/docs/src/manual/quick-start.md
@@ -11,10 +11,3 @@
 >     ```
 >     ] add EnergyModelsGeography
 >     ```
-
-!!! note
-    If you receive the error that `EnergyModelsGeography` is not yet registered, you have to add the package using the GitHub repository through
-    ```
-    ] add https://github.com/EnergyModelsX/EnergyModelsGeography.jl
-    ```
-    Once the package is registered, this is not required.


### PR DESCRIPTION
The contribution section is similar as the one in [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/how-to/contribute/), but focuses on the specific contribution options for `EnergyModelsGeography`.

This PR corresponds to the request from the [JOSS submission](https://github.com/EnergyModelsX/EnergyModelsBase.jl/issues/21). 