### PR TITLE
Improvement of function calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # Release notes
 
+## Version 0.9.0 (2024-05-24)
+
+### Update on function calls for dispatching on `modeltype`
+
+* Introduced `modeltype` as argument for all create and constraint functions.
+* Moved constraint on installed capacity to function `constraints_capacity_installed` to replicate the dispatch behaviour from `EnergyModelsBase`.
+
+## Version 0.8.5 (2024-05-24)
+
+* Update of dependencies and adjustment to changes in `EnergyModelsBase` v0.7.
+
 ## Version 0.8.4 (2024-05-09)
 
 * Provided a contribution section in the documentation.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsGeography"
 uuid = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 authors = ["Espen Flo Bødal <Espen.Bodal@sintef.no>"]
-version = "0.8.5"
+version = "0.9.0"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,6 +19,7 @@ Pages = [
     "manual/transmission-mode.md",
     "manual/simple-example.md"
 ]
+Depth = 1
 ```
 
 ## How to guides
@@ -27,6 +28,7 @@ Pages = [
 Pages = [
     "how-to/contribute.md",
 ]
+Depth = 1
 ```
 
 ## Library outline
@@ -36,4 +38,5 @@ Pages = [
     "library/public.md",
     "library/internals/reference.md",
     ]
+Depth = 1
 ```

--- a/docs/src/manual/constraint-functions.md
+++ b/docs/src/manual/constraint-functions.md
@@ -8,7 +8,7 @@ In later implementation, it is planned to also use dispatch for this analysis as
 ## Capacity constraints
 
 ```julia
-constraints_capacity(m, tm::TransmissionMode, 𝒯::TimeStructure)
+constraints_capacity(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 ```
 
 correponds to the constraints on the capacity usage of a transmission mode ``tm``.
@@ -17,10 +17,31 @@ The key difference between the former two is related that `PipeMode` does not al
 `PipeLinepackSimple` includes in addition the maximum storage capacity for a pipeline when considering linepacking.
 The implementation is still preliminary and based on a simplified potential for energy storage in a pipeline.
 
+Within this function, the function
+
+```julia
+constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
+```
+
+is called to limit the variable ``\texttt{trans\_cap\_inst}`` of transmission mode ``tm``.
+This functions is also used to subsequently dispatch on model type for the introduction of investments.
+
+!!! warning
+    As the function `constraints_capacity_installed` is used for including investments for tranmission modes, it is important that it is also called when creating a new mode.
+    It is not possible to only add a function for
+    ```julia
+    constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
+    ```
+    without adding a function for
+    ```julia
+    constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EMI.AbstractInvestmentModel)
+    ```
+    as this can lead to a method ambiguity error.
+
 ## Transmission loss functions
 
 ```julia
-constraints_trans_loss(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ)
+constraints_trans_loss(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
 ```
 
 correponds to the constraints on the energy balance of a transmission mode ``tm``.
@@ -31,7 +52,7 @@ The loss is calculated for the provided `TransmissionMode`s as relative loss of 
 ## Balance functions
 
 ```julia
-constraints_trans_balance(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ)
+constraints_trans_balance(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
 ```
 
 correponds to the constraints on the energy balance of a transmission mode ``tm``.
@@ -48,7 +69,7 @@ The standard approach only relies on the conservation of mass/energy, while stor
 ## Operational expenditure constraints
 
 ```julia
-constraints_opex_fixed(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ)
+constraints_opex_fixed(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
 ```
 
 corresponds to the constraints calculating the fixed operational costs of a transmission mode `tm`.
@@ -56,7 +77,7 @@ There is currently only a single implemented version.
 It can however be extended, if desirable.
 
 ```julia
-constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ)
+constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
 ```
 
 corresponds to the constraints calculating the variable operational costs of a transmission mode `tm`.

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -180,7 +180,7 @@ function get_sub_system_data(
     NG, Coal, Power, CO2 = products
 
     # Use of standard demand if not provided differently
-    d_standard = OperationalProfile([10, 10, 10, 10, 35, 40, 45, 45, 50, 50, 60, 60, 50, 45, 45, 40, 35, 40, 45, 40, 35, 30, 30, 30])
+    d_standard = OperationalProfile([20, 20, 20, 20, 25, 30, 35, 35, 40, 40, 40, 40, 40, 35, 35, 30, 25, 30, 35, 30, 25, 20, 20, 20])
     if demand == false
         demand = [d_standard; d_standard; d_standard; d_standard]
         demand *= d_scale
@@ -225,12 +225,14 @@ function get_sub_system_data(
                 Dict(Power => 1),           # Output from the node with output ratio
                 [EmissionsEnergy()],        # Additonal data for emissions
             ),
-            RefStorage(
+            RefStorage{AccumulatingEmissions}(
                 j+6,                        # Node id
-                FixedProfile(20),           # Rate capacity in t/h
-                FixedProfile(600),          # Storage capacity in t
-                FixedProfile(9.1),          # Storage variable OPEX for the rate in EUR/t
-                FixedProfile(0),            # Storage fixed OPEX for the rate in EUR/(t/h 24h)
+                StorCapOpex(
+                    FixedProfile(20),       # Charge capacity in t/h
+                    FixedProfile(9.1),      # Storage variable OPEX for the charging in EUR/t
+                    FixedProfile(0),        # Storage fixed OPEX for the charging in EUR/(t/h 8h)
+                ),
+                StorCap(FixedProfile(600)), # Storage capacity in t
                 CO2,                        # Stored resource
                 Dict(CO2 => 1, Power => 0.02), # Input resource with input ratio
                 # Line above: This implies that storing CO2 requires Power

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -1,10 +1,10 @@
 """
-    constraints_capacity(m, tm::TransmissionMode, 𝒯::TimeStructure)
+    constraints_capacity(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
 Function for creating the constraint on the maximum capacity of a generic `TransmissionMode`.
 This function serves as fallback option if no other function is specified for a `TransmissionMode`.
 """
-function constraints_capacity(m, tm::TransmissionMode, 𝒯::TimeStructure)
+function constraints_capacity(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
     # Upper limit defined by installed capacity
     @constraint(m, [t ∈ 𝒯],
@@ -24,15 +24,15 @@ function constraints_capacity(m, tm::TransmissionMode, 𝒯::TimeStructure)
     end
 
     # Add constraints for the installed capacity
-    constraints_capacity_installed(m, tm, 𝒯)
+    constraints_capacity_installed(m, tm, 𝒯, modeltype)
 end
 
 """
-    constraints_capacity(m, tm::PipeMode, 𝒯::TimeStructure)
+    constraints_capacity(m, tm::PipeMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
 Function for creating the constraint on the maximum capacity of a generic `PipeMode`.
 """
-function constraints_capacity(m, tm::PipeMode, 𝒯::TimeStructure)
+function constraints_capacity(m, tm::PipeMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
     # Upper and lower limit defined by installed capacity
     @constraint(m, [t ∈ 𝒯],
@@ -50,15 +50,15 @@ function constraints_capacity(m, tm::PipeMode, 𝒯::TimeStructure)
     end
 
     # Add constraints for the installed capacity
-    constraints_capacity_installed(m, tm, 𝒯)
+    constraints_capacity_installed(m, tm, 𝒯, modeltype)
 end
 
 """
-    constraints_capacity(m, tm::PipeLinepackSimple, 𝒯::TimeStructure)
+    constraints_capacity(m, tm::PipeLinepackSimple, 𝒯::TimeStructure, modeltype::EnergyModel)
 
 Function for creating the constraint on the maximum capacity of a `PipeLinepackSimple`.
 """
-function constraints_capacity(m, tm::PipeLinepackSimple, 𝒯::TimeStructure)
+function constraints_capacity(m, tm::PipeLinepackSimple, 𝒯::TimeStructure, modeltype::EnergyModel)
 
     # Upper and lower transmission limit defined by installed capacity
     @constraint(m, [t ∈ 𝒯],
@@ -83,15 +83,15 @@ function constraints_capacity(m, tm::PipeLinepackSimple, 𝒯::TimeStructure)
     end
 
     # Add constraints for the installed capacity
-    constraints_capacity_installed(m, tm, 𝒯)
+    constraints_capacity_installed(m, tm, 𝒯, modeltype)
 end
 
 """
-    constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStructure)
+    constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
 Function for creating the constraint on the installed capacity of a `TransmissionMode`.
 """
-function constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStructure)
+function constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
     # Fix the installed capacity to the upper bound
     for t ∈ 𝒯
@@ -101,12 +101,12 @@ end
 
 
 """
-    constraints_trans_loss(m, tm::TransmissionMode, 𝒯::TimeStructure)
+    constraints_trans_loss(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
 Function for creating the constraint on the transmission loss of a generic `TransmissionMode`.
 This function serves as fallback option if no other function is specified for a `TransmissionMode`.
 """
-function constraints_trans_loss(m, tm::TransmissionMode, 𝒯::TimeStructure)
+function constraints_trans_loss(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
     if is_bidirectional(tm)
         # The total loss equals the sum of negative and positive loss (absolute loss)
@@ -130,11 +130,11 @@ function constraints_trans_loss(m, tm::TransmissionMode, 𝒯::TimeStructure)
 end
 
 """
-    constraints_trans_loss(m, tm::PipeMode, 𝒯::TimeStructure)
+    constraints_trans_loss(m, tm::PipeMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
 Function for creating the constraint on the transmission loss of a generic `PipeMode`.
 """
-function constraints_trans_loss(m, tm::PipeMode, 𝒯::TimeStructure)
+function constraints_trans_loss(m, tm::PipeMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
 
     @constraint(m, [t ∈ 𝒯],
@@ -149,12 +149,12 @@ end
 
 
 """
-    constraints_trans_balance(m, tm::TransmissionMode, 𝒯::TimeStructure)
+    constraints_trans_balance(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
 Function for creating the transmission balance for a generic `TransmissionMode`.
 This function serves as fallback option if no other function is specified for a `TransmissionMode`.
 """
-function constraints_trans_balance(m, tm::TransmissionMode, 𝒯::TimeStructure)
+function constraints_trans_balance(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
     @constraint(m, [t ∈ 𝒯],
         m[:trans_out][tm, t] == m[:trans_in][tm, t] - m[:trans_loss][tm, t])
@@ -162,11 +162,11 @@ function constraints_trans_balance(m, tm::TransmissionMode, 𝒯::TimeStructure)
 end
 
 """
-    constraints_trans_balance(m, tm::PipeLinepackSimple, 𝒯::TimeStructure)
+    constraints_trans_balance(m, tm::PipeLinepackSimple, 𝒯::TimeStructure, modeltype::EnergyModel)
 
 Function for creating the transmission balance for a`PipeLinepackSimple`.
 """
-function constraints_trans_balance(m, tm::PipeLinepackSimple, 𝒯::TimeStructure)
+function constraints_trans_balance(m, tm::PipeLinepackSimple, 𝒯::TimeStructure, modeltype::EnergyModel)
 
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
     for t_inv ∈ 𝒯ᴵⁿᵛ, (t_prev, t) ∈ withprev(t_inv)
@@ -195,12 +195,12 @@ end
 
 
 """
-    constraints_opex_fixed(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ)
+    constraints_opex_fixed(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
 
 Function for creating the constraint on the fixed OPEX of a generic `TransmissionMode`.
 This function serves as fallback option if no other function is specified for a `TransmissionMode`.
 """
-function constraints_opex_fixed(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ)
+function constraints_opex_fixed(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
 
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         m[:trans_opex_fixed][tm, t_inv] ==
@@ -210,12 +210,12 @@ end
 
 
 """
-    constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ)
+    constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
 
 Function for creating the constraint on the variable OPEX of a generic `TransmissionMode`.
 This function serves as fallback option if no other function is specified for a `TransmissionMode`.
 """
-function constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ)
+function constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
 
     if is_bidirectional(tm)
         @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -173,7 +173,7 @@ function constraints_trans_balance(m, tm::PipeLinepackSimple, 𝒯::TimeStructur
         # Periodicity constraint
         if isnothing(t_prev)
             @constraint(m, m[:linepack_stor_level][tm, t] ==
-                           m[:linepack_stor_level][tm, last(collect(t_inv))] +
+                           m[:linepack_stor_level][tm, last(t_inv)] +
                            (m[:trans_in][tm, t] - m[:trans_loss][tm, t] - m[:trans_out][tm, t])
                            * duration(t)
             )

--- a/src/model.jl
+++ b/src/model.jl
@@ -63,24 +63,21 @@ time periods `t ∈ 𝒯`.
 """
 function variables_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, modeltype::EnergyModel)
     @variable(m, area_exchange[a ∈ 𝒜, 𝒯, p ∈ exchange_resources(ℒᵗʳᵃⁿˢ, a)])
-
 end
 
 
 """
-    variables_trans_capex(m, 𝒯, ℒᵗʳᵃⁿˢ, modeltype)
+    variables_trans_capex(m, 𝒯, ℳ, modeltype::EnergyModel)
 
 Create variables for the capital costs for the investments in transmission.
 Empty function to allow for multiple dispatch in the `EnergyModelsInvestment` package.
 """
-function variables_trans_capex(m, 𝒯, ℳ, modeltype::EnergyModel)
-
-end
+function variables_trans_capex(m, 𝒯, ℳ, modeltype::EnergyModel) end
 
 """
-    variables_trans_opex(m, 𝒯, ℒᵗʳᵃⁿˢ, modeltype)
+    variables_trans_opex(m, 𝒯, ℳ, modeltype::EnergyModel)
 
-Create variables for the operational costs for the investments in transmission.
+Declaration of variables for the operational costs of the tranmission modes.
 """
 function variables_trans_opex(m, 𝒯, ℳ, modeltype::EnergyModel)
 
@@ -91,21 +88,14 @@ function variables_trans_opex(m, 𝒯, ℳ, modeltype::EnergyModel)
 end
 
 """
-    variables_trans_capacity(m, 𝒯, ℳ, modeltype)
+    variables_trans_capacity(m, 𝒯, ℳ, modeltype::EnergyModel)
 
-Create variables to track how much of installed transmision capacity is used for all
-time periods `t ∈ 𝒯`.
+Declaration of variables for tracking how much of installed transmision capacity is used f
+or all time periods `t ∈ 𝒯` of the tranmission modes.
 """
-function variables_trans_capacity(m, 𝒯, ℳ, modeltype)
-
-    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    𝒯ᴵⁿᵛ
+function variables_trans_capacity(m, 𝒯, ℳ, modeltype::EnergyModel)
 
     @variable(m, trans_cap[ℳ, 𝒯] >= 0)
-
-    for tm ∈ ℳ, t ∈ 𝒯
-        @constraint(m, trans_cap[tm, t] == capacity(tm, t))
-    end
 end
 
 
@@ -181,7 +171,6 @@ Adds the following special variables for linepacking:
 function variables_trans_mode(m, 𝒯, ℳᴸᴾ::Vector{<:PipeLinepackSimple}, modeltype::EnergyModel)
 
     @variable(m, linepack_stor_level[ℳᴸᴾ, 𝒯] >= 0)
-
 end
 
 
@@ -228,9 +217,7 @@ end
 Repaces constraints for availability nodes of type GeoAvailability.
 The resource balances are set by the area constraints instead.
 """
-function EMB.create_node(m, n::GeoAvailability, 𝒯, 𝒫, modeltype::EnergyModel)
-
-end
+function EMB.create_node(m, n::GeoAvailability, 𝒯, 𝒫, modeltype::EnergyModel) end
 
 
 """
@@ -238,9 +225,7 @@ end
 
 Default fallback method when no function is defined for a node type.
 """
-function create_area(m, a::Area, 𝒯, ℒᵗʳᵃⁿˢ, modeltype)
-
-end
+function create_area(m, a::Area, 𝒯, ℒᵗʳᵃⁿˢ, modeltype) end
 
 """
     create_area(m, a::LimitedExchangeArea, 𝒯, ℒᵗʳᵃⁿˢ, modeltype)

--- a/src/model.jl
+++ b/src/model.jl
@@ -252,7 +252,7 @@ Create transmission constraints on all transmission corridors.
 function constraints_transmission(m, 𝒯, ℳ, modeltype::EnergyModel)
 
     for tm ∈ ℳ
-        create_transmission_mode(m, tm, 𝒯)
+        create_transmission_mode(m, tm, 𝒯, modeltype)
     end
 end
 
@@ -279,26 +279,27 @@ end
 
 
 """
-    create_transmission_mode(m, 𝒯, tm)
+    create_transmission_mode(m, tm::TransmissionMode, 𝒯, modeltype::EnergyModel)
 
-Set all constraints for transmission mode. Serves as a fallback option for unspecified subtypes of `TransmissionMode`.
+Set all constraints for transmission mode. Serves as a fallback option for unspecified
+subtypes of `TransmissionMode`.
 """
-function create_transmission_mode(m, tm::TransmissionMode, 𝒯)
+function create_transmission_mode(m, tm::TransmissionMode, 𝒯, modeltype::EnergyModel)
 
     # Defining the required sets
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Call of the function for tranmission balance
     # Generic trans in which each output corresponds to the input minus losses
-    constraints_trans_balance(m, tm, 𝒯)
+    constraints_trans_balance(m, tm, 𝒯, modeltype)
 
     # Call of the functions for tranmission losses
-    constraints_trans_loss(m, tm, 𝒯)
+    constraints_trans_loss(m, tm, 𝒯, modeltype)
 
     # Call of the function for limiting the capacity to the maximum installed capacity
-    constraints_capacity(m, tm, 𝒯)
+    constraints_capacity(m, tm, 𝒯, modeltype)
 
     # Call of the functions for both fixed and variable OPEX constraints introduction
-    constraints_opex_fixed(m, tm, 𝒯ᴵⁿᵛ)
-    constraints_opex_var(m, tm, 𝒯ᴵⁿᵛ)
+    constraints_opex_fixed(m, tm, 𝒯ᴵⁿᵛ, modeltype)
+    constraints_opex_var(m, tm, 𝒯ᴵⁿᵛ, modeltype)
 end

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -12,8 +12,8 @@ Generic representation of dynamic transmission modes, using for example truck, s
 - **`trans_cap::TimeProfile`** is the capacity of the transmission mode.\n
 - **`trans_loss::TimeProfile`** is the loss of the transported resource during \
 transmission, modelled as a ratio.\n
-- **`opex_var::TimeProfile`** is the variational operational costs per energy unit transported.\n
-- **`opex_fixed::TimeProfile`** is the fixed operational costs per installed capacity.\n
+- **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.\n
+- **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.\n
 - **`directions`** is the number of directions the resource can be transported, \
 1 is unidirectional (A->B) or 2 is bidirectional (A<->B).\n
 - **`data::Vector{Data}`** is the additional data (e.g. for investments). The field \
@@ -51,8 +51,8 @@ Generic representation of static transmission modes, such as overhead power line
 - **`trans_cap::Real`** is the capacity of the transmission mode.\n
 - **`trans_loss::Real`** is the loss of the transported resource during transmission, \
 modelled as a ratio.\n
-- **`opex_var::TimeProfile`** is the variational operational costs per energy unit transported.\n
-- **`opex_fixed::TimeProfile`** is the fixed operational costs per installed capacity.\n
+- **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.\n
+- **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.\n
 - **`directions`** is the number of directions the resource can be transported, \
 1 is unidirectional (A->B) or 2 is bidirectional (A<->B).\n
 - **`data::Vector{Data}`** is the additional data (e.g. for investments). The field \
@@ -106,8 +106,8 @@ consumed, as a ratio of the volume of the resource going into the inlet. I.e.:
         `consumption_rate` = consumed volume / inlet volume (per operational period)\n
 - **`trans_cap::Real`** is the capacity of the transmission mode.\n
 - **`trans_loss::Real`** is the loss of the transported resource during transmission, modelled as a ratio.\n
-- **`opex_var::TimeProfile`** is the variational operational costs per energy unit transported.\n
-- **`opex_fixed::TimeProfile`** is the fixed operational costs per installed capacity.\n
+- **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.\n
+- **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.\n
 - **`directions`** specifies that the pipeline is Unidirectional (1) by default.\n
 - **`data::Vector{Data}`** is the additional data (e.g. for investments).
 """

--- a/test/test_simplelinepack.jl
+++ b/test/test_simplelinepack.jl
@@ -123,7 +123,7 @@ end
                         value.(m[:trans_out][pipeline, t]))*duration(t),
                     value.(m[:linepack_stor_level][pipeline, t]) -
                         (isnothing(t_prev) ?
-                            value.(m[:linepack_stor_level][pipeline, last(collect(t_inv))]) :
+                            value.(m[:linepack_stor_level][pipeline, last(t_inv)]) :
                             value.(m[:linepack_stor_level][pipeline, t_prev])
                         ),
                     atol=TEST_ATOL

--- a/test/test_simplelinepack.jl
+++ b/test/test_simplelinepack.jl
@@ -123,7 +123,7 @@ end
                         value.(m[:trans_out][pipeline, t]))*duration(t),
                     value.(m[:linepack_stor_level][pipeline, t]) -
                         (isnothing(t_prev) ?
-                            value.(m[:linepack_stor_level][pipeline, last(t_inv)]) :
+                            value.(m[:linepack_stor_level][pipeline, last(collect(t_inv))]) :
                             value.(m[:linepack_stor_level][pipeline, t_prev])
                         ),
                     atol=TEST_ATOL


### PR DESCRIPTION
So far, we used in `EnergyModelsGeography` the old approach for introducing constraints on the capacities through dispatching on the function `variables_capacity`. This approach was discontinued in `EnergyModelsBase` v0.3.3 as it led to potential method ambiguities. Instead, a function `constraints_capacity_installed` was introduced.

This PR replicates these changes now in `EnergyModelsGeography`.

In addition the following changes were incorporated:
- Changes in some docstrings
- Adding the argument `modeltype` to a large fraction of the functions.