### PR TITLE
Fix bug on variable OPEX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           - version: '1.9'  # 1.9
             os: ubuntu-latest
             arch: x86
-          - version: 'nightly'
-            os: ubuntu-latest
-            arch: x64
+          # - version: 'nightly'
+          #   os: ubuntu-latest
+          #   arch: x64
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 # Release notes
 
-## Unversioned
+## Version 0.9.1 (2024-05-24)
+
+### Bugfix
+
+* The variable OPEX for unidirectional transmission modes was wrongly calculated as it did not take into account the scaling provided through the optional keyword argument `op_per_strat` of `TimeStruct`.
+
+### Other
 
 * Use dev version of EMG for examples when running as part of tests, similar to [PR #33 of EMB](https://github.com/EnergyModelsX/EnergyModelsBase.jl/pull/33).
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsGeography"
 uuid = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 authors = ["Espen Flo Bødal <Espen.Bodal@sintef.no>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -204,7 +204,7 @@ function constraints_opex_fixed(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltyp
 
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         m[:trans_opex_fixed][tm, t_inv] ==
-        opex_fixed(tm, t_inv) * m[:trans_cap][tm, first(t_inv)]
+            opex_fixed(tm, t_inv) * m[:trans_cap][tm, first(t_inv)]
     )
 end
 
@@ -221,14 +221,13 @@ function constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype:
         @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
             m[:trans_opex_var][tm, t_inv] ==
                 opex_var(tm, t_inv) *
-                sum((m[:trans_pos][tm, t] + m[:trans_neg][tm, t]) *
-                    duration(t) * multiple_strat(t_inv, t) * probability(t)
+                    sum((m[:trans_pos][tm, t] + m[:trans_neg][tm, t]) * EMB.multiple(t_inv, t)
                 for t ∈ t_inv)
         )
     else
         @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
             m[:trans_opex_var][tm, t_inv] ==
-            sum(m[:trans_out][tm, t] * opex_var(tm, t) * duration(t) for t ∈ t_inv)
+                sum(m[:trans_out][tm, t] * opex_var(tm, t) * EMB.multiple(t_inv, t) for t ∈ t_inv)
         )
     end
 end

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -220,14 +220,17 @@ function constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype:
     if is_bidirectional(tm)
         @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
             m[:trans_opex_var][tm, t_inv] ==
-                opex_var(tm, t_inv) *
-                    sum((m[:trans_pos][tm, t] + m[:trans_neg][tm, t]) * EMB.multiple(t_inv, t)
-                for t ∈ t_inv)
+                    sum(
+                        (m[:trans_pos][tm, t] + m[:trans_neg][tm, t]) *
+                        opex_var(tm, t_inv) * EMB.multiple(t_inv, t)
+                    for t ∈ t_inv)
         )
     else
         @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
             m[:trans_opex_var][tm, t_inv] ==
-                sum(m[:trans_out][tm, t] * opex_var(tm, t) * EMB.multiple(t_inv, t) for t ∈ t_inv)
+                sum(
+                    m[:trans_out][tm, t] * opex_var(tm, t) * EMB.multiple(t_inv, t)
+                for t ∈ t_inv)
         )
     end
 end


### PR DESCRIPTION
The previous approach treated the calculation of variable OPEX differently in the case of bidirectional and unidirectional transport. In the latter case, it did not take into account the scaling factor `op_per_strat` which is provided by `TimeStruct` which leads to an underestimation of the variable operating expenses. This is fixed in this PR.