### PR TITLE
Inclusion of potential for `TransmissionMode` emissions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,18 @@
 # Release notes
 
-## Unversioned
+## Version 0.10.0 (2024-08-20)
 
 ### Introduced `EnergyModelsInvestments` as extension
 
 * `EnergyModelsInvestments` was switched to be an independent package in [PR #28](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/pull/28).
 * This approach required `EnergyModelsGeography` to include all functions and type declarations internally.
 * An extension was introduced to handle these problems.
+
+### Introduced potential for emissions of `TransmissionMode`s
+
+* As outlined in [Issue 9](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/issues/9), there is a requirement for potential emissions from `TransmissionMode`s.
+* The clean approach was not achieved within a certain timeframe, hence, a limited approach is implemented based on the initial provided branches in both [`EMB`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/tree/0.7/emissions) and [`EMG`](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/tree/0.9/emissions).
+* The implementation is **not** tested!
 
 ## Version 0.9.1 (2024-05-24)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 0.10.0 (2024-08-20)
+## Unversioned
 
 ### Introduced `EnergyModelsInvestments` as extension
 

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -236,19 +236,23 @@ function constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype:
 end
 
 """
-    constraints_emission(m, tm::TransmissionMode, 𝒯)
+    constraints_emission(m, tm::TransmissionMode, 𝒯, modeltype::EnergyModel)
 
-Function for creating the constraints on the emissions of a generic `TransmissionMode`.
-This function serves as fallback option if no other function is specified for a `TransmissionMode`.
+Function for creating the constraints on the emissions of a generic `TransmissionMode` `tm`.
+This function serves as fallback option if no other function is specified for a
+`TransmissionMode`.
 """
-function constraints_emission(m, tm::TransmissionMode, 𝒯)
-    for t ∈ 𝒯
-        for p ∈ emit_resources(tm)
-            if directions(tm) == 1
-                @constraint(m, m[:trans_emission][tm, t, p] == emission(tm, p, t) * m[:trans_out][tm, t])
-            elseif  directions(tm) == 2
-                @constraint(m, m[:trans_emission][tm, t, p] == emission(tm, p, t) * (m[:trans_pos][tm, t] + m[:trans_neg][tm, t]))
-            end
-        end
+function constraints_emission(m, tm::TransmissionMode, 𝒯, modeltype::EnergyModel)
+
+    if is_bidirectional(tm)
+        @constraint(m, [t ∈ 𝒯, p_em ∈ emit_resources(tm)],
+            m[:emissions_trans][tm, t, p_em] ==
+                emission(tm, p_em, t) * (m[:trans_pos][tm, t] + m[:trans_neg][tm, t])
+        )
+    else
+        @constraint(m, [t ∈ 𝒯, p_em ∈ emit_resources(tm)],
+            m[:emissions_trans][tm, t, p_em] ==
+                emission(tm, p_em, t) * m[:trans_out][tm, t]
+        )
     end
 end

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -234,3 +234,21 @@ function constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype:
         )
     end
 end
+
+"""
+    constraints_emission(m, tm::TransmissionMode, 𝒯)
+
+Function for creating the constraints on the emissions of a generic `TransmissionMode`.
+This function serves as fallback option if no other function is specified for a `TransmissionMode`.
+"""
+function constraints_emission(m, tm::TransmissionMode, 𝒯)
+    for t ∈ 𝒯
+        for p ∈ emit_resources(tm)
+            if directions(tm) == 1
+                @constraint(m, m[:trans_emission][tm, t, p] == emission(tm, p, t) * m[:trans_out][tm, t])
+            elseif  directions(tm) == 2
+                @constraint(m, m[:trans_emission][tm, t, p] == emission(tm, p, t) * (m[:trans_pos][tm, t] + m[:trans_neg][tm, t]))
+            end
+        end
+    end
+end

--- a/src/model.jl
+++ b/src/model.jl
@@ -312,10 +312,10 @@ function update_total_emissions(m, 𝒯, ℳ, 𝒫, modeltype::EnergyModel)
     ℳᵉᵐ = filter(m -> has_emissions(m), ℳ)
     𝒫ᵉᵐ  = EMB.res_sub(𝒫, EMB.ResourceEmit)
 
-    # Modify existing constraints on total emsission by adding contribution from
-    # transmission emissions. Note the coefficient set to -1 since the total constraint
+    # Modify existing constraints on total emissions by adding contribution from
+    # transmission emissions. Note the coefficient is set to -1 since the total constraint
     # has the variables on the RHS.
-    for tm ∈ ℳᵉᵐ,  p ∈ 𝒫ᵉᵐ, t ∈ 𝒯
+    for tm ∈ ℳᵉᵐ, p ∈ 𝒫ᵉᵐ, t ∈ 𝒯
         JuMP.set_normalized_coefficient(m[:con_em_tot][t, p], m[:emissions_trans][tm, t, p], -1.0)
     end
 end
@@ -343,7 +343,7 @@ function create_transmission_mode(m, tm::TransmissionMode, 𝒯, modeltype::Ener
     # Call of the function for limiting the capacity to the maximum installed capacity
     constraints_capacity(m, tm, 𝒯, modeltype)
 
-    # Call of the functions for tranmission emissions
+    # Call of the functions for transmission emissions
     constraints_emission(m, tm, 𝒯, modeltype)
 
     # Call of the functions for both fixed and variable OPEX constraints introduction

--- a/src/model.jl
+++ b/src/model.jl
@@ -40,10 +40,14 @@ function create_model(case, modeltype::EnergyModel, m::JuMP.Model; check_timepro
     variables_trans_opex(m, 𝒯, ℳ, modeltype)
     variables_trans_capacity(m, 𝒯, ℳ, modeltype)
     variables_trans_modes(m, 𝒯, ℳ, modeltype)
+    variables_trans_emission(m, 𝒯, ℳ, 𝒫, modeltype)
 
     # Construction of constraints for areas and transmission corridors
     constraints_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, 𝒫, modeltype)
     constraints_transmission(m, 𝒯, ℳ, modeltype)
+
+    # Updates the global constraint on total emissions
+    update_total_emissions(m, 𝒯, ℳ, 𝒫, modeltype)
 
     # Updates the objective function
     update_objective(m, 𝒯, ℳ, modeltype)
@@ -173,6 +177,19 @@ function variables_trans_mode(m, 𝒯, ℳᴸᴾ::Vector{<:PipeLinepackSimple}, 
     @variable(m, linepack_stor_level[ℳᴸᴾ, 𝒯] >= 0)
 end
 
+"""
+    variables_trans_emission(m, 𝒯, ℳ, 𝒫, modeltype)
+
+Creates variables for the modeling of tranmission emissions. These variables
+are only created for transmission modes where emissions are included.
+"""
+function variables_trans_emission(m, 𝒯, ℳ, 𝒫, modeltype)
+    ℳᵉᵐ = filter(m -> hasemissions(m), ℳ)
+    𝒫ᵉᵐ  = EMB.res_sub(𝒫, ResourceEmit)
+    @variable(m, trans_emission[ℳᵉᵐ, 𝒯, 𝒫ᵉᵐ] >= 0)
+end
+
+
 
 """
     constraints_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, 𝒫, modeltype::EnergyModel)
@@ -277,6 +294,27 @@ function update_objective(m, 𝒯, ℳ, modeltype::EnergyModel)
     @objective(m, Max, obj)
 end
 
+"""
+    update_total_emissions(m, 𝒯, ℳ, 𝒫, modeltype::EnergyModel)
+
+Update the constraints aggregating total emissions in each time period
+with contributions from transmission emissions.
+"""
+function update_total_emissions(m, 𝒯, ℳ, 𝒫, modeltype::EnergyModel)
+
+    ℳᵉᵐ = filter(m -> hasemissions(m), ℳ)
+    𝒫ᵉᵐ  = EMB.res_sub(𝒫, EMB.ResourceEmit)
+
+    # Modify existing constraints on total emsission by adding contribution from
+    # transmission emissions. Note the coefficient set to -1 since the total constraint
+    # has the variables on the RHS.
+    for tm ∈ ℳᵉᵐ,  p ∈ 𝒫ᵉᵐ, t ∈ 𝒯
+        JuMP.set_normalized_coefficient(m[:con_em_tot][t, p], m[:trans_emission][tm, t, p], -1.0)
+    end
+
+end
+
+
 
 """
     create_transmission_mode(m, tm::TransmissionMode, 𝒯, modeltype::EnergyModel)
@@ -298,6 +336,9 @@ function create_transmission_mode(m, tm::TransmissionMode, 𝒯, modeltype::Ener
 
     # Call of the function for limiting the capacity to the maximum installed capacity
     constraints_capacity(m, tm, 𝒯, modeltype)
+
+    # Call of the functions for tranmission emissions
+    constraints_emission(m, tm, 𝒯)
 
     # Call of the functions for both fixed and variable OPEX constraints introduction
     constraints_opex_fixed(m, tm, 𝒯ᴵⁿᵛ, modeltype)

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -2,6 +2,29 @@
 abstract type TransmissionMode end
 Base.show(io::IO, t::TransmissionMode) = print(io, "$(t.id)")
 
+"""
+    hasemissions(m::TransmissionMode)
+
+Returns whether there are emissions associated with the transmisson mode.
+Default behaviour is no emissions.
+"""
+hasemissions(m::TransmissionMode) = false
+
+"""
+    emit_resources(m::TransmissionMode)
+
+Returns the types of emisssions associated with the transmission mode.
+"""
+emit_resources(m::TransmissionMode) = EMB.ResourceEmit[]
+
+"""
+    emission(m::TransmissionMode, p::EMB.ResourceEmit, t)
+
+Returns the emission of a specific resource in a time period t per unit transmitted.
+"""
+emission(m::TransmissionMode, p::EMB.ResourceEmit, t) = 0
+
+
 """ A reference dynamic `TransmissionMode`.
 
 Generic representation of dynamic transmission modes, using for example truck, ship or railway transport.

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -283,7 +283,7 @@ directions(tm::TransmissionMode) = tm.directions
 """
     has_emissions(tm::TransmissionMode)
 
-Returns whether there are emissions associated with transmisson mode `tm`.
+Returns whether there are emissions associated with transmission mode `tm`.
 Default behaviour is no emissions.
 """
 has_emissions(tm::TransmissionMode) = false
@@ -291,21 +291,21 @@ has_emissions(tm::TransmissionMode) = false
 """
     emit_resources(m::TransmissionMode)
 
-Returns the types of emisssions associated with transmission mode `tm`.
+Returns the types of emissions associated with transmission mode `tm`.
 """
 emit_resources(tm::TransmissionMode) = EMB.ResourceEmit[]
 
 """
     emission(tm::TransmissionMode, p::EMB.ResourceEmit)
 
-Returns the emission of tasmission mode `tm` of a specific resource `p` as `TimeProfile`
+Returns the emission of transmission mode `tm` of a specific resource `p` as `TimeProfile`
 """
 emission(tm::TransmissionMode, p::EMB.ResourceEmit) = 0
 
 """
     emission(tm::TransmissionMode, p::EMB.ResourceEmit, t)
 
-Returns the emission of tasmission mode `tm` of a specific resource `p` at time period `t`
+Returns the emission of transmission mode `tm` of a specific resource `p` at time period `t`
 per unit transmitted.
 """
 emission(tm::TransmissionMode, p::EMB.ResourceEmit, t) = 0

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -2,28 +2,6 @@
 abstract type TransmissionMode end
 Base.show(io::IO, t::TransmissionMode) = print(io, "$(t.id)")
 
-"""
-    hasemissions(m::TransmissionMode)
-
-Returns whether there are emissions associated with the transmisson mode.
-Default behaviour is no emissions.
-"""
-hasemissions(m::TransmissionMode) = false
-
-"""
-    emit_resources(m::TransmissionMode)
-
-Returns the types of emisssions associated with the transmission mode.
-"""
-emit_resources(m::TransmissionMode) = EMB.ResourceEmit[]
-
-"""
-    emission(m::TransmissionMode, p::EMB.ResourceEmit, t)
-
-Returns the emission of a specific resource in a time period t per unit transmitted.
-"""
-emission(m::TransmissionMode, p::EMB.ResourceEmit, t) = 0
-
 
 """ A reference dynamic `TransmissionMode`.
 
@@ -301,6 +279,36 @@ loss(tm::TransmissionMode, t) = tm.trans_loss[t]
 Returns the directions of transmission mode `tm`.
 """
 directions(tm::TransmissionMode) = tm.directions
+
+"""
+    has_emissions(tm::TransmissionMode)
+
+Returns whether there are emissions associated with transmisson mode `tm`.
+Default behaviour is no emissions.
+"""
+has_emissions(tm::TransmissionMode) = false
+
+"""
+    emit_resources(m::TransmissionMode)
+
+Returns the types of emisssions associated with transmission mode `tm`.
+"""
+emit_resources(tm::TransmissionMode) = EMB.ResourceEmit[]
+
+"""
+    emission(tm::TransmissionMode, p::EMB.ResourceEmit)
+
+Returns the emission of tasmission mode `tm` of a specific resource `p` as `TimeProfile`
+"""
+emission(tm::TransmissionMode, p::EMB.ResourceEmit) = 0
+
+"""
+    emission(tm::TransmissionMode, p::EMB.ResourceEmit, t)
+
+Returns the emission of tasmission mode `tm` of a specific resource `p` at time period `t`
+per unit transmitted.
+"""
+emission(tm::TransmissionMode, p::EMB.ResourceEmit, t) = 0
 
 """
     consumption_rate(tm::PipeMode)


### PR DESCRIPTION
As outlined in [Issue 9](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/issues/9), there is a demand for inclusion of emissions for `TransmissionMode`s. As we did not manage to change the implementation outlined in said issue, we reverted to the initial approach of modifying the coefficients in the named constraints (included in [EMB PR 36](https://github.com/EnergyModelsX/EnergyModelsBase.jl/pull/36)).

The more concise approach should be discussed in [Issue 37 of EnergyModelsBase](https://github.com/EnergyModelsX/EnergyModelsBase.jl/issues/37)