### PR TITLE
Improvement of types `PipeSimple` and `PipeLinepackSimple`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 # Release notes
 
-## Unversioned
+## Version 0.10.0 (2024-05-24)
+
+### Changed `PipeSimple` and `PipeLinepackSimple` types
+
+* Moved away from `@kwdef` to avoid having to specify potentially all field names.
+* Included an inner constructor for limiting the field directions to 1 to avoid issues in the calculations.
 
 ### Introduced `EnergyModelsInvestments` as extension
 
@@ -14,7 +19,7 @@
 * The clean approach was not achieved within a certain timeframe, hence, a limited approach is implemented based on the initial provided branches in both [`EMB`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/tree/0.7/emissions) and [`EMG`](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/tree/0.9/emissions).
 * The implementation is **not** tested!
 
-## Version 0.9.1 (2024-05-24)
+## Version 0.9.1 (2024-08-19)
 
 ### Bugfix
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -49,6 +49,7 @@ makedocs(
             "Release notes" => "manual/NEWS.md",
         ],
         "How to" => Any[
+            "Update models"=>"how-to/update-models.md",
             "Contribute to EnergyModelsGeography" => "how-to/contribute.md",
         ],
         "Library" => Any[

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -49,7 +49,7 @@ makedocs(
             "Release notes" => "manual/NEWS.md",
         ],
         "How to" => Any[
-            "Update models"=>"how-to/update-models.md",
+            "Update models" => "how-to/update-models.md",
             "Contribute to EnergyModelsGeography" => "how-to/contribute.md",
         ],
         "Library" => Any[

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -11,7 +11,7 @@ We will as well implement information regarding the adjustment of extension pack
 
 Version 0.10 removed the keyword definition of [`PipeSimple`](@ref) and [`PipeLinepackSimple`](@ref).
 A key aim behind this removal is to avoid having to specify the fields if one does not provide a value to the data or the directions field.
-This was solved through:
+This was solved through
 
 1. an internal constructor only allowing for unidirectional pipelines and
 2. an external constructor for cases in which the field `data` is not specified.

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -1,0 +1,124 @@
+# [Update your model to the latest versions](@id how_to-update)
+
+`EnergyModelsGeography` is still in a pre-release version.
+Hence, there are frequently breaking changes occuring, although we plan to keep backwards compatibility.
+This document is designed to provide users with information regarding how they have to adjust their models to keep compatibility to the latest changes.
+We will as well implement information regarding the adjustment of extension packages, although this is more difficult due to the vast majority of potential changes.
+
+## [Adjustments from 0.9.x](@id how_to-update-09)
+
+### [Key changes for transmission mode descriptions](@id how_to-update-06-mode)
+
+Version 0.10 removed the keywrod definition of [`PipeSimple`](@ref) and [`PipeLinepackSimple`](@ref).
+A key aim behind this removal is to avoid having to specify the fields if one does not provide a value to the data or the directions field.
+THis was solved through
+
+1. an internal constructor only allowing for unidirectional pipelines and
+2. an external constructor for cases in which the field `data` is not specified.
+
+Bidirectional transport for pipelines was removed as the model did not support it.
+A key factor here is the `consuming` resource which is required for pumping or compression energy demand.
+In the case of bidirectional transport, the `consuming` resource is consumed in the `from` region.
+In the case of reversed flow, this would lead to undesired behavior.
+Previously, warnings were printed.
+We consider it to be more consistent with the framework philosophy to remove that potential source of error.
+
+!!! danger "New subtypes for `PipeMode`"
+    It is still possible for the user to provide new [`PipeMode`](@ref)s that provide bidirectional transport.
+    In this case, it is necessary to provide new methods for [`constraints_capacity`](@ref man-con-cap) and [`constraints_trans_loss`](@ref man-con-trans_loss).
+    Otherwise, warnings will be provided and unidirectional transport used.
+
+    The variable OPEX calculation is wrong if you receive the warnings.
+
+The translations below describe the keyword constructor.
+You only have to remove the entry to the field of directions.
+
+!!! note "Timeline for constructors"
+    The legacy constructors for calls of the composite types of version 0.9 will be included at least until version 0.11.
+    However, it is recommended to update your model as soon as possible to the latest version.
+
+### [`PipeSimple`](@ref)
+
+```julia
+# The previous description for PipeSimple was given by:
+PipeSimple(;
+    id::String,
+    inlet::EMB.Resource,
+    outlet::EMB.Resource,
+    consuming::EMB.Resource,
+    consumption_rate::TimeProfile,
+    trans_cap::TimeProfile,
+    trans_loss::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    directions::Int = 1,            # This value cannot be specified any longer
+    data::Vector{Data} = Data[],
+)
+
+# This translates to the following new version
+ PipeSimple(
+    id,
+    inlet,
+    outlet,
+    consuming,
+    consumption_rate,
+    trans_cap,
+    trans_loss,
+    opex_var,
+    opex_fixed,
+    data,
+)
+```
+
+### [`PipeLinepackSimple`](@ref)
+
+```julia
+# The previous description for PipeLinepackSimple was given by:
+PipeLinepackSimple(;
+    id::String,
+    inlet::EMB.Resource,
+    outlet::EMB.Resource,
+    consuming::EMB.Resource,
+    consumption_rate::TimeProfile,
+    trans_cap::TimeProfile,
+    trans_loss::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    energy_share::Float64,
+    directions::Int = 1,            # This value cannot be specified any longer
+    data::Vector{Data} = Data[],
+)
+
+# This translates to the following new version
+PipeLinepackSimple(
+    id,
+    inlet,
+    outlet,
+    consuming,
+    consumption_rate,
+    trans_cap,
+    trans_loss,
+    opex_var,
+    opex_fixed,
+    energy_share,
+    data,
+)
+```
+
+## [Adjustments from 0.7.x](@id how_to-update-07)
+
+### [`GeoAvailability`](@ref)
+
+`GeoAvailability` nodes do not require any longer the data for `input` and `output`, as they utilize a constructor, if only a single array is given.
+
+```julia
+# The previous nodal description was given by:
+GeoAvailability(
+    id,
+    input::Dict{<:Resource,<:Real},
+    output::Dict{<:Resource,<:Real},
+)
+
+# This translates to the following new version
+GeoAvailability(id, collect(keys(input)), collect(keys(output)))
+```

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -9,9 +9,9 @@ We will as well implement information regarding the adjustment of extension pack
 
 ### [Key changes for transmission mode descriptions](@id how_to-update-06-mode)
 
-Version 0.10 removed the keywrod definition of [`PipeSimple`](@ref) and [`PipeLinepackSimple`](@ref).
+Version 0.10 removed the keyword definition of [`PipeSimple`](@ref) and [`PipeLinepackSimple`](@ref).
 A key aim behind this removal is to avoid having to specify the fields if one does not provide a value to the data or the directions field.
-THis was solved through
+This was solved through:
 
 1. an internal constructor only allowing for unidirectional pipelines and
 2. an external constructor for cases in which the field `data` is not specified.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,6 +27,7 @@ Depth = 1
 
 ```@contents
 Pages = [
+    "how-to/update-models.md",
     "how-to/contribute.md",
 ]
 Depth = 1

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -103,7 +103,7 @@ energy_share
 
 ### [`InvestmentData` types](@id lib-pub-inv_data-types)
 
-Transmission mode investmentments utilize the same investment data type ([`SingleInvData](@extref EnergyModelsBase.SingleInvData)) as investments in node capacities.
+Transmission mode investments utilize the same investment data type ([`SingleInvData`](@extref EnergyModelsBase.SingleInvData)) as investments in node capacities.
 
 ### [Legacy constructors](@id lib-pub-inv_data-leg)
 

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -43,12 +43,6 @@ function constraints_capacity(m, tm::PipeMode, 𝒯::TimeStructure, modeltype::E
         set_lower_bound(m[:trans_in][tm, t], 0)
     end
 
-    # Bi-directional not allowed for PipeMode
-    if is_bidirectional(tm)
-        @warn "Only uni-directional tranmission is allowed for TransmissionMode of type
-        $(typeof(tm)), uni-directional constraints for capacity is implemented for $tm."
-    end
-
     # Add constraints for the installed capacity
     constraints_capacity_installed(m, tm, 𝒯, modeltype)
 end
@@ -76,12 +70,6 @@ function constraints_capacity(m, tm::PipeLinepackSimple, 𝒯::TimeStructure, mo
     @constraint(m, [t ∈ 𝒯],
         m[:linepack_stor_level][tm, t] <= energy_share(tm) * m[:trans_cap][tm, t])
 
-    # Bi-directional not allowed for PipeMode
-    if is_bidirectional(tm)
-        @warn "Only uni-directional tranmission is allowed for TransmissionMode of type
-        $(typeof(tm)), uni-directional constraints for capacity is implemented for $tm."
-    end
-
     # Add constraints for the installed capacity
     constraints_capacity_installed(m, tm, 𝒯, modeltype)
 end
@@ -99,7 +87,6 @@ function constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStruc
     end
 end
 
-
 """
     constraints_trans_loss(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
@@ -115,8 +102,8 @@ function constraints_trans_loss(m, tm::TransmissionMode, 𝒯::TimeStructure, mo
                 loss(tm, t) * (m[:trans_pos][tm, t] + m[:trans_neg][tm, t])
         )
 
-        # The positive and negative conponents of flow on a transmission mode
-        # (depends on the dicrestion a mode is defined)
+        # The positive and negative conponents of flow of a transmission mode
+        # depends on the direction a mode is defined
         @constraint(m, [t ∈ 𝒯],
             m[:trans_pos][tm, t] - m[:trans_neg][tm, t] ==
                 0.5 * (m[:trans_in][tm, t] + m[:trans_out][tm, t])
@@ -126,7 +113,6 @@ function constraints_trans_loss(m, tm::TransmissionMode, 𝒯::TimeStructure, mo
             m[:trans_loss][tm, t] == loss(tm, t) * m[:trans_in][tm, t]
         )
     end
-
 end
 
 """
@@ -136,17 +122,9 @@ Function for creating the constraint on the transmission loss of a generic `Pipe
 """
 function constraints_trans_loss(m, tm::PipeMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 
-
     @constraint(m, [t ∈ 𝒯],
         m[:trans_loss][tm, t] == loss(tm, t) * m[:trans_in][tm, t])
-
-    if is_bidirectional(tm)
-        @warn "Only uni-directional tranmission is allowed for TransmissionMode of type
-        $(typeof(tm)), uni-directional constraint for loss is implemented for $tm."
-    end
-
 end
-
 
 """
     constraints_trans_balance(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
@@ -193,7 +171,6 @@ function constraints_trans_balance(m, tm::PipeLinepackSimple, 𝒯::TimeStructur
 
 end
 
-
 """
     constraints_opex_fixed(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)
 
@@ -207,7 +184,6 @@ function constraints_opex_fixed(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltyp
             opex_fixed(tm, t_inv) * m[:trans_cap][tm, first(t_inv)]
     )
 end
-
 
 """
     constraints_opex_var(m, tm::TransmissionMode, 𝒯ᴵⁿᵛ, modeltype::EnergyModel)

--- a/src/legacy_constructors.jl
+++ b/src/legacy_constructors.jl
@@ -32,7 +32,7 @@ end
 
 Legacy constructor for a `PipeSimple`.
 This version will be discontinued in the near future and replaced with the new version that
-is no longer using the field directions
+is no longer using the field directions.
 
 See the *[documentation](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/how-to/update-models)*
 for further information regarding how you can translate your existing model to the new model.
@@ -54,7 +54,7 @@ function PipeSimple(
         "The used implementation of a `PipeSimple` will be discontinued in the near future. " *
         "See the documentation for the new implementation in which we no longer utilize " *
         "the keyword constructor.\n" *
-        "The only change required is to remove the keywords or alternatively the value for" *
+        "The only change required is to remove the keywords or alternatively the value for " *
         "directions.",
         maxlog = 1
     )
@@ -90,7 +90,7 @@ function PipeSimple(;
         "The used implementation of a `PipeSimple` will be discontinued in the near future. " *
         "See the documentation for the new implementation in which we no longer utilize " *
         "the keyword constructor.\n" *
-        "The only change required is to remove the keywords or alternatively the value for" *
+        "The only change required is to remove the keywords or alternatively the value for " *
         "directions.",
         maxlog = 1
     )
@@ -128,7 +128,7 @@ end
 
 Legacy constructor for a `PipeLinepackSimple`.
 This version will be discontinued in the near future and replaced with the new version that
-is no longer using the field directions
+is no longer using the field directions.
 
 See the *[documentation](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/how-to/update-models)*
 for further information regarding how you can translate your existing model to the new model.

--- a/src/legacy_constructors.jl
+++ b/src/legacy_constructors.jl
@@ -14,3 +14,198 @@ function GeoAvailability(
 
     return GeoAvailability(id, collect(keys(input)), collect(keys(output)))
 end
+
+"""
+    PipeSimple(
+        id::String,
+        inlet::EMB.Resource,
+        outlet::EMB.Resource,
+        consuming::EMB.Resource,
+        consumption_rate::TimeProfile,
+        trans_cap::TimeProfile,
+        trans_loss::TimeProfile,
+        opex_var::TimeProfile,
+        opex_fixed::TimeProfile,
+        directions::Int = 1
+        data::Vector{Data} = Data[]
+    )
+
+Legacy constructor for a `PipeSimple`.
+This version will be discontinued in the near future and replaced with the new version that
+is no longer using the field directions
+
+See the *[documentation](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/how-to/update-models)*
+for further information regarding how you can translate your existing model to the new model.
+"""
+function PipeSimple(
+    id::String,
+    inlet::EMB.Resource,
+    outlet::EMB.Resource,
+    consuming::EMB.Resource,
+    consumption_rate::TimeProfile,
+    trans_cap::TimeProfile,
+    trans_loss::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    directions::Int,
+    data::Vector{Data},
+)
+    @warn(
+        "The used implementation of a `PipeSimple` will be discontinued in the near future. " *
+        "See the documentation for the new implementation in which we no longer utilize " *
+        "the keyword constructor.\n" *
+        "The only change required is to remove the keywords or alternatively the value for" *
+        "directions.",
+        maxlog = 1
+    )
+
+    tmp = PipeSimple(
+        id,
+        inlet,
+        outlet,
+        consuming,
+        consumption_rate,
+        trans_cap,
+        trans_loss,
+        opex_var,
+        opex_fixed,
+        data,
+    )
+    return tmp
+end
+function PipeSimple(;
+    id::String,
+    inlet::EMB.Resource,
+    outlet::EMB.Resource,
+    consuming::EMB.Resource,
+    consumption_rate::TimeProfile,
+    trans_cap::TimeProfile,
+    trans_loss::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    directions::Int = 1,
+    data::Vector{Data} = Data[],
+)
+    @warn(
+        "The used implementation of a `PipeSimple` will be discontinued in the near future. " *
+        "See the documentation for the new implementation in which we no longer utilize " *
+        "the keyword constructor.\n" *
+        "The only change required is to remove the keywords or alternatively the value for" *
+        "directions.",
+        maxlog = 1
+    )
+
+    tmp = PipeSimple(
+        id,
+        inlet,
+        outlet,
+        consuming,
+        consumption_rate,
+        trans_cap,
+        trans_loss,
+        opex_var,
+        opex_fixed,
+        data,
+    )
+    return tmp
+end
+
+"""
+    PipeLinepackSimple(
+        id::String,
+        inlet::EMB.Resource,
+        outlet::EMB.Resource,
+        consuming::EMB.Resource,
+        consumption_rate::TimeProfile,
+        trans_cap::TimeProfile,
+        trans_loss::TimeProfile,
+        opex_var::TimeProfile,
+        opex_fixed::TimeProfile,
+        energy_share::Float64,
+        directions::Int = 1
+        data::Vector{Data} = Data[]
+    )
+
+Legacy constructor for a `PipeLinepackSimple`.
+This version will be discontinued in the near future and replaced with the new version that
+is no longer using the field directions
+
+See the *[documentation](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/how-to/update-models)*
+for further information regarding how you can translate your existing model to the new model.
+"""
+function PipeLinepackSimple(
+    id::String,
+    inlet::EMB.Resource,
+    outlet::EMB.Resource,
+    consuming::EMB.Resource,
+    consumption_rate::TimeProfile,
+    trans_cap::TimeProfile,
+    trans_loss::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    energy_share::Float64,
+    directions::Int,
+    data::Vector{Data},
+)
+    @warn(
+        "The used implementation of a `PipeLinepackSimple` will be discontinued in the near future. " *
+        "See the documentation for the new implementation in which we no longer utilize " *
+        "the keyword constructor.\n" *
+        "The only change required is to remove the keywords or alternatively the value for " *
+        "directions.",
+        maxlog = 1
+    )
+
+    tmp = PipeLinepackSimple(
+        id,
+        inlet,
+        outlet,
+        consuming,
+        consumption_rate,
+        trans_cap,
+        trans_loss,
+        opex_var,
+        opex_fixed,
+        energy_share,
+        data,
+    )
+    return tmp
+end
+function PipeLinepackSimple(;
+    id::String,
+    inlet::EMB.Resource,
+    outlet::EMB.Resource,
+    consuming::EMB.Resource,
+    consumption_rate::TimeProfile,
+    trans_cap::TimeProfile,
+    trans_loss::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    energy_share::Float64,
+    directions::Int = 1,
+    data::Vector{Data} = Data[],
+)
+    @warn(
+        "The used implementation of a `PipeLinepackSimple` will be discontinued in the near future. " *
+        "See the documentation for the new implementation in which we no longer utilize " *
+        "the keyword constructor.\n" *
+        "The only change required is to remove the keywords or alternatively the value for " *
+        "directions.",
+        maxlog = 1
+    )
+
+    tmp = PipeLinepackSimple(
+        id,
+        inlet,
+        outlet,
+        consuming,
+        consumption_rate,
+        trans_cap,
+        trans_loss,
+        opex_var,
+        opex_fixed,
+        energy_share,
+        data,
+    )
+    return tmp
+end

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,5 +1,5 @@
 """
-    create_model(case, modeltype::EnergyModel; check_timeprofiles::Bool=true)
+    create_model(case, modeltype::EnergyModel, m::JuMP.Model; check_timeprofiles::Bool=true)
 
 Create the model and call all required functions.
 
@@ -69,7 +69,6 @@ function variables_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, modeltype::EnergyModel)
     @variable(m, area_exchange[a ∈ 𝒜, 𝒯, p ∈ exchange_resources(ℒᵗʳᵃⁿˢ, a)])
 end
 
-
 """
     variables_trans_capex(m, 𝒯, ℳ, modeltype::EnergyModel)
 
@@ -101,7 +100,6 @@ function variables_trans_capacity(m, 𝒯, ℳ, modeltype::EnergyModel)
 
     @variable(m, trans_cap[ℳ, 𝒯] >= 0)
 end
-
 
 """
     variables_trans_modes(m, 𝒯, ℳ, modeltype::EnergyModel)
@@ -149,9 +147,9 @@ are:
 * `:trans_out` - outlet flow from a transmission mode
 * `:trans_loss` - loss during transmission
 * `:trans_loss_neg` - negative loss during transmission, helper variable if bidirectional
-transport is possible
+  transport is possible
 * `:trans_loss_pos` - positive loss during transmission, helper variable if bidirectional
-transport is possible
+  transport is possible
 """
 function variables_trans_mode(m, 𝒯, ℳˢᵘᵇ::Vector{<:TransmissionMode}, modeltype::EnergyModel)
 
@@ -163,7 +161,6 @@ function variables_trans_mode(m, 𝒯, ℳˢᵘᵇ::Vector{<:TransmissionMode}, 
     @variable(m, trans_neg[ℳ2, 𝒯] >= 0)
     @variable(m, trans_pos[ℳ2, 𝒯] >= 0)
 end
-
 
 """
     variables_trans_mode(m, 𝒯, ℳᴸᴾ::Vector{<:PipeLinepackSimple}, modeltype::EnergyModel)
@@ -194,7 +191,7 @@ function variables_trans_emission(m, 𝒯, ℳ, 𝒫, modeltype)
     @variable(m, emissions_trans[ℳᵉᵐ, 𝒯, 𝒫ᵉᵐ] >= 0)
 
     # Fix of unused emission variables to avoid free variables
-    for tm ∈ ℳᵉᵐ, p_em ∈ setdiff(𝒫ᵉᵐ, emit_resources(tm)), t ∈ 𝒯
+    for tm ∈ ℳᵉᵐ, t ∈ 𝒯, p_em ∈ setdiff(𝒫ᵉᵐ, emit_resources(tm))
         fix(m[:emissions_trans][tm, t, p_em], 0; force = true)
     end
 end
@@ -244,7 +241,6 @@ The resource balances are set by the area constraints instead.
 """
 function EMB.create_node(m, n::GeoAvailability, 𝒯, 𝒫, modeltype::EnergyModel) end
 
-
 """
     create_area(m, a::Area, 𝒯, ℒᵗʳᵃⁿˢ, modeltype)
 
@@ -268,7 +264,6 @@ function create_area(m, a::LimitedExchangeArea, 𝒯, ℒᵗʳᵃⁿˢ, modeltyp
 
 end
 
-
 """
     constraints_transmission(m, 𝒯, ℳ, modeltype::EnergyModel)
 
@@ -280,7 +275,6 @@ function constraints_transmission(m, 𝒯, ℳ, modeltype::EnergyModel)
         create_transmission_mode(m, tm, 𝒯, modeltype)
     end
 end
-
 
 """
     update_objective(m, 𝒩, 𝒯, 𝒫, ℒᵗʳᵃⁿˢ, modeltype::EnergyModel)
@@ -319,8 +313,6 @@ function update_total_emissions(m, 𝒯, ℳ, 𝒫, modeltype::EnergyModel)
         JuMP.set_normalized_coefficient(m[:con_em_tot][t, p], m[:emissions_trans][tm, t, p], -1.0)
     end
 end
-
-
 
 """
     create_transmission_mode(m, tm::TransmissionMode, 𝒯, modeltype::EnergyModel)

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -10,7 +10,7 @@ A reference dynamic `TransmissionMode`.
 Generic representation of dynamic transmission modes, using for example truck, ship or railway transport.
 
 # Fields
-- **`id::String`** is the name/identifyer of the transmission mode.
+- **`id::String`** is the name/identifier of the transmission mode.
 - **`resource::Resource`** is the resource that is transported.
 - **`trans_cap::TimeProfile`** is the capacity of the transmission mode.
 - **`trans_loss::TimeProfile`** is the loss of the transported resource during
@@ -52,7 +52,7 @@ A reference static `TransmissionMode`.
 Generic representation of static transmission modes, such as overhead power lines or pipelines.
 
 # Fields
-- **`id::String`** is the name/identifyer of the transmission mode.
+- **`id::String`** is the name/identifier of the transmission mode.
 - **`resource::Resource`** is the resource that is transported.
 - **`trans_cap::Real`** is the capacity of the transmission mode.
 - **`trans_loss::Real`** is the loss of the transported resource during transmission,

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -163,7 +163,8 @@ struct PipeSimple <: PipeMode
             opex_var,
             opex_fixed,
             1,
-            data)
+            data,
+            )
     end
 end
 function PipeSimple(
@@ -187,7 +188,8 @@ function PipeSimple(
         trans_loss,
         opex_var,
         opex_fixed,
-        Data[])
+        Data[],
+        )
 end
 
 """
@@ -237,7 +239,7 @@ struct PipeLinepackSimple <: PipeMode
         opex_var::TimeProfile,
         opex_fixed::TimeProfile,
         energy_share::Float64,
-        data::Vector{<:Data}
+        data::Vector{<:Data},
     )
         new(
             id,
@@ -251,7 +253,7 @@ struct PipeLinepackSimple <: PipeMode
             opex_fixed,
             energy_share,
             1,
-            data
+            data,
         )
     end
 end

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -2,23 +2,25 @@
 abstract type TransmissionMode end
 Base.show(io::IO, t::TransmissionMode) = print(io, "$(t.id)")
 
+"""
+    RefDynamic <: TransmissionMode
 
-""" A reference dynamic `TransmissionMode`.
+A reference dynamic `TransmissionMode`.
 
 Generic representation of dynamic transmission modes, using for example truck, ship or railway transport.
 
 # Fields
-- **`id::String`** is the name/identifyer of the transmission mode.\n
-- **`resource::Resource`** is the resource that is transported.\n
-- **`trans_cap::TimeProfile`** is the capacity of the transmission mode.\n
-- **`trans_loss::TimeProfile`** is the loss of the transported resource during \
-transmission, modelled as a ratio.\n
-- **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.\n
-- **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.\n
-- **`directions`** is the number of directions the resource can be transported, \
-1 is unidirectional (A->B) or 2 is bidirectional (A<->B).\n
-- **`data::Vector{Data}`** is the additional data (e.g. for investments). The field \
-`data` is conditional through usage of a constructor.
+- **`id::String`** is the name/identifyer of the transmission mode.
+- **`resource::Resource`** is the resource that is transported.
+- **`trans_cap::TimeProfile`** is the capacity of the transmission mode.
+- **`trans_loss::TimeProfile`** is the loss of the transported resource during
+  transmission, modelled as a ratio.
+- **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.
+- **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.
+- **`directions`** is the number of directions the resource can be transported,
+  1 is unidirectional (A->B) or 2 is bidirectional (A<->B).
+- **`data::Vector{Data}`** is the additional data (e.g. for investments). The field `data`
+  is conditional through usage of a constructor.
 """
 struct RefDynamic <: TransmissionMode # E.g. Trucks, ships etc.
     id::String
@@ -42,22 +44,25 @@ function RefDynamic(
     return RefDynamic(id, resource, trans_cap, trans_loss, opex_var, opex_fixed, directions, Data[])
 end
 
-""" A reference static `TransmissionMode`.
+"""
+    RefStatic <: TransmissionMode
+
+A reference static `TransmissionMode`.
 
 Generic representation of static transmission modes, such as overhead power lines or pipelines.
 
 # Fields
-- **`id::String`** is the name/identifyer of the transmission mode.\n
-- **`resource::Resource`** is the resource that is transported.\n
-- **`trans_cap::Real`** is the capacity of the transmission mode.\n
-- **`trans_loss::Real`** is the loss of the transported resource during transmission, \
-modelled as a ratio.\n
-- **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.\n
-- **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.\n
-- **`directions`** is the number of directions the resource can be transported, \
-1 is unidirectional (A->B) or 2 is bidirectional (A<->B).\n
-- **`data::Vector{Data}`** is the additional data (e.g. for investments). The field \
-`data` is conditional through usage of a constructor.
+- **`id::String`** is the name/identifyer of the transmission mode.
+- **`resource::Resource`** is the resource that is transported.
+- **`trans_cap::Real`** is the capacity of the transmission mode.
+- **`trans_loss::Real`** is the loss of the transported resource during transmission,
+  modelled as a ratio.
+- **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.
+- **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.
+- **`directions`** is the number of directions the resource can be transported,
+  1 is unidirectional (A->B) or 2 is bidirectional (A<->B).
+- **`data::Vector{Data}`** is the additional data (e.g. for investments). The field `data`
+  is conditional through usage of a constructor.
 """
 struct RefStatic <: TransmissionMode # E.g. overhead power lines, pipelines etc.
     id::String
@@ -82,13 +87,19 @@ function RefStatic(
 end
 
 
-""" `TransmissionMode` mode for additional variable potential."""
+"""
+    PipeMode <: TransmissionMode
+
+`TransmissionMode` mode for additional variable potential.
+"""
 abstract type PipeMode <: TransmissionMode end
 
 """
+    PipeSimple <: PipeMode
+
 This `TransmissionMode` allows for altering the transported `Resource`.
 
-A usage of this could e.g. be by defining a subtype struct of Resource with the field
+A usage of this could e.g. be by defining a subtype struct of `Resource` with the field
 'pressure'. This PipelineMode can then take `SomeSubtype<:Resource` with pressure p₁ at the
 inlet, and pressure p₂ at the outlet.
 
@@ -96,25 +107,28 @@ This type also supports consuming resources proportionally to the volume of tran
 `Resource` (at the inlet). This could be used for modeling the power needed for operating
 the pipeline.
 
+Pipeline transport using `PipeSimple` is assumed to be unidirectional. It is not possible to
+use `PipeSimple` for bidirectional transport as the consuming resource would in this case
+be consumed at the wrong `Area`.
+
 # Fields
-- **`id::String`** is the identifier used in printed output.\n
-- **`inlet::Resource`** is the `Resource` going into transmission.\n
-- **`outlet::Resource`** is the `Resource` going out of the outlet of the transmission.\n
-- **`consuming::Resource`** is the `Resource` the transmission consumes by operating.\n
-- **`consumption_rate::Real`** the rate of which the resource `Pipeline.consuming` is \
-consumed, as a ratio of the volume of the resource going into the inlet. I.e.:
-
-        `consumption_rate` = consumed volume / inlet volume (per operational period)\n
-- **`trans_cap::Real`** is the capacity of the transmission mode.\n
-- **`trans_loss::Real`** is the loss of the transported resource during transmission, modelled as a ratio.\n
-- **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.\n
-- **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.\n
-- **`directions`** specifies that the pipeline is Unidirectional (1) by default.\n
-- **`data::Vector{Data}`** is the additional data (e.g. for investments).
+- **`id::String`** is the identifier used in printed output.
+- **`inlet::Resource`** is the `Resource` going into transmission.
+- **`outlet::Resource`** is the `Resource` going out of the outlet of the transmission.
+- **`consuming::Resource`** is the `Resource` the transmission consumes by operating.
+- **`consumption_rate::Real`** the rate of which the resource `Pipeline.consuming` is
+  consumed, as a ratio of the volume of the resource going into the inlet, i.e.:\n
+        `consumption_rate` = consumed volume / inlet volume (per operational period)
+- **`trans_cap::Real`** is the capacity of the transmission mode.
+- **`trans_loss::Real`** is the loss of the transported resource during transmission,
+  modelled as a ratio.
+- **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.
+- **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.
+- **`data::Array{<:Data}`** is the additional data (e.g. for investments). The field `data`
+  is conditional through usage of a constructor.
 """
-Base.@kwdef struct PipeSimple <: PipeMode
+struct PipeSimple <: PipeMode
     id::String
-
     inlet::EMB.Resource
     outlet::EMB.Resource
     consuming::EMB.Resource
@@ -123,21 +137,82 @@ Base.@kwdef struct PipeSimple <: PipeMode
     trans_loss::TimeProfile
     opex_var::TimeProfile
     opex_fixed::TimeProfile
-    # TODO remove below field? Should not be relevant for fluid pipeline.
-    directions::Int = 1     # 1: Unidirectional only for pipeline
-    data::Vector{Data} = Data[]
+    directions::Int
+    data::Vector{<:Data}
+
+    function PipeSimple(
+        id::String,
+        inlet::EMB.Resource,
+        outlet::EMB.Resource,
+        consuming::EMB.Resource,
+        consumption_rate::TimeProfile,
+        trans_cap::TimeProfile,
+        trans_loss::TimeProfile,
+        opex_var::TimeProfile,
+        opex_fixed::TimeProfile,
+        data::Vector{<:Data}
+    )
+        new(
+            id,
+            inlet,
+            outlet,
+            consuming,
+            consumption_rate,
+            trans_cap,
+            trans_loss,
+            opex_var,
+            opex_fixed,
+            1,
+            data)
+    end
+end
+function PipeSimple(
+    id::String,
+    inlet::EMB.Resource,
+    outlet::EMB.Resource,
+    consuming::EMB.Resource,
+    consumption_rate::TimeProfile,
+    trans_cap::TimeProfile,
+    trans_loss::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+)
+    PipeSimple(
+        id,
+        inlet,
+        outlet,
+        consuming,
+        consumption_rate,
+        trans_cap,
+        trans_loss,
+        opex_var,
+        opex_fixed,
+        Data[])
 end
 
 """
-    PipeLinepackSimple <: TransmissionMode
+    PipeLinepackSimple <: PipeMode
+
 Pipeline model with linepacking implemented as simple storage function.
 
 # Fields (additional to `PipeSimple`)
-- **`energy_share::Float64`**  - is the storage energy capacity relative to pipeline capacity.\n
-- **`Level_share_init::Float64`**  - is the initial storage level. \n
-- **`data::Vector{Data}`** is the additional data (e.g. for investments).
+- **`id::String`** is the identifier used in printed output.
+- **`inlet::Resource`** is the `Resource` going into transmission.
+- **`outlet::Resource`** is the `Resource` going out of the outlet of the transmission.
+- **`consuming::Resource`** is the `Resource` the transmission consumes by operating.
+- **`consumption_rate::Real`** the rate of which the resource `Pipeline.consuming` is
+  consumed, as a ratio of the volume of the resource going into the inlet, i.e.:\n
+        `consumption_rate` = consumed volume / inlet volume (per operational period)
+- **`trans_cap::Real`** is the capacity of the transmission mode.
+- **`trans_loss::Real`** is the loss of the transported resource during transmission,
+  modelled as a ratio.
+- **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.
+- **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.
+- **`energy_share::Float64`** is the storage energy capacity relative to pipeline capacity.
+- **`data::Array{<:Data}`** is the additional data (e.g. for investments). The field `data`
+  is conditional through usage of a constructor.
 """
-Base.@kwdef struct PipeLinepackSimple <: PipeMode
+struct PipeLinepackSimple <: PipeMode
     id::String
     inlet::EMB.Resource
     outlet::EMB.Resource
@@ -147,9 +222,64 @@ Base.@kwdef struct PipeLinepackSimple <: PipeMode
     trans_loss::TimeProfile
     opex_var::TimeProfile
     opex_fixed::TimeProfile
-    energy_share::Float64 # Storage energy capacity relative to pipeline capacity
-    directions::Int = 1     # 1: Unidirectional only for pipeline
-    data::Vector{Data} = Data[]
+    energy_share::Float64
+    directions::Int
+    data::Vector{<:Data}
+
+    function PipeLinepackSimple(
+        id::String,
+        inlet::EMB.Resource,
+        outlet::EMB.Resource,
+        consuming::EMB.Resource,
+        consumption_rate::TimeProfile,
+        trans_cap::TimeProfile,
+        trans_loss::TimeProfile,
+        opex_var::TimeProfile,
+        opex_fixed::TimeProfile,
+        energy_share::Float64,
+        data::Vector{<:Data}
+    )
+        new(
+            id,
+            inlet,
+            outlet,
+            consuming,
+            consumption_rate,
+            trans_cap,
+            trans_loss,
+            opex_var,
+            opex_fixed,
+            energy_share,
+            1,
+            data
+        )
+    end
+end
+function PipeLinepackSimple(
+    id::String,
+    inlet::EMB.Resource,
+    outlet::EMB.Resource,
+    consuming::EMB.Resource,
+    consumption_rate::TimeProfile,
+    trans_cap::TimeProfile,
+    trans_loss::TimeProfile,
+    opex_var::TimeProfile,
+    opex_fixed::TimeProfile,
+    energy_share::Float64,
+)
+
+    PipeLinepackSimple(
+        id,
+        inlet,
+        outlet,
+        consuming,
+        consumption_rate,
+        trans_cap,
+        trans_loss,
+        opex_var,
+        opex_fixed,
+        energy_share,
+        Data[])
 end
 
 """

--- a/test/test_geo_unidirectional.jl
+++ b/test/test_geo_unidirectional.jl
@@ -127,19 +127,16 @@ end
     # Replace each TransmissionMode's with a PipeSimple with identical properties.
     for transmission in case[:transmission]
         for (i, prev_tm) ∈ enumerate(modes(transmission))
-            pipeline = EMG.PipeSimple(repr(prev_tm),
+            pipeline = PipeSimple(repr(prev_tm),
                                         inputs(prev_tm)[1],
                                         inputs(prev_tm)[1],
                                         inputs(prev_tm)[1], # Doesn't matter when Consumption_rate = 0
                                         FixedProfile(0),
-                                        prev_tm.trans_cap,
-                                        prev_tm.trans_loss,
-                                        prev_tm.opex_var,
-                                        prev_tm.opex_fixed,
-                                        directions(prev_tm),
-                                        Data[]
+                                        capacity(prev_tm),
+                                        loss(prev_tm),
+                                        opex_var(prev_tm),
+                                        opex_fixed(prev_tm),
                                         )
-            @assert directions(prev_tm) == 1 "The Direction mode should be unidirectional."
             modes(transmission)[i] = pipeline
         end
     end

--- a/test/test_simplelinepack.jl
+++ b/test/test_simplelinepack.jl
@@ -45,8 +45,6 @@ function small_graph_linepack()
         FixedProfile(0.05),   # Opex var
         FixedProfile(0.05),   # Opex fixed
         0.1,                  # Storage capacity
-        1,
-        Data[]
         )
 
     transmissions = [Transmission(areas[1], areas[2], [pipeline])]

--- a/test/test_simplepipe.jl
+++ b/test/test_simplepipe.jl
@@ -43,7 +43,7 @@ function small_graph_co2_1()
 
     pipeline = PipeSimple(
         "pipeline", CO2_150, CO2_200, Power, FixedProfile(0.1), FixedProfile(100),
-        FixedProfile(0.05), FixedProfile(0.05), FixedProfile(0.05), 1, Data[])
+        FixedProfile(0.05), FixedProfile(0.05), FixedProfile(0.05))
 
     transmissions = [Transmission(areas[1], areas[2], [pipeline])]
 
@@ -94,7 +94,7 @@ end
     el_sink = 𝒩[5]
 
     transmission = case[:transmission][1]
-    pipeline::EMG.PipeSimple = modes(transmission)[1]
+    pipeline = modes(transmission)[1]
     inlet_resource = pipeline.inlet
     outlet_resource = pipeline.outlet
 


### PR DESCRIPTION
We used so far as `@kwdef` for both `PipeSimple` and `PipeLinepackSimple`. This approach required specifying all field names in the case one wanted to omit either the field `directions` or `data`. As this require an unnecessary amount of typing, it was changed to a standard composite type.

The field direction is still existing, but it is no longer possible to specify it. Previously, we used warnings in cases in which the value was not 1 as `EMG` does not support bidirectional pipeline transport. This potential source of error was now removed through the application of inner constructors.

**Once this PR is merged, we will register v0.10 of EMG.**