### PR TITLE
Nodes in an area

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Unversioned
+
+* Included a new method for identifying nodes within an area using breadth-first search.
+  This method allows for an arbitrary connection of links between a node and the availability node.
+* Minor typo updates in the documentation.
+
 ## Version 0.10.1 (2024-10-16)
 
 ### Minor updates

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ If you find `EnergyModelsGeography` useful in your work, we kindly request that 
   number = {97},
   pages = {6619},
   year = {2024},
-  doi = {https://doi.org/10.21105/joss.06619},
+  doi = {10.21105/joss.06619},
+  url = {https://doi.org/10.21105/joss.06619},
 }
 ```
 
@@ -41,7 +42,7 @@ For earlier work, see our [paper in Applied Energy](https://www.sciencedirect.co
   pages = {122484},
   year = {2024},
   issn = {0306-2619},
-  doi = {https://doi.org/10.1016/j.apenergy.2023.122484},
+  doi = {10.1016/j.apenergy.2023.122484},
   url = {https://www.sciencedirect.com/science/article/pii/S0306261923018482},
   author = {Espen Flo B{\o}dal and Sigmund Eggen Holm and Avinash Subramanian and Goran Durakovic and Dimitri Pinel and Lars Hellemo and Miguel Mu{\~n}oz Ortiz and Brage Rugstad Knudsen and Julian Straus}
 }

--- a/docs/src/area_mode/mode.md
+++ b/docs/src/area_mode/mode.md
@@ -141,7 +141,7 @@ The following standard constraints are implemented for a [`TransmissionMode`](@r
   \texttt{trans\_out}[tm, t] \leq \texttt{trans\_cap}[tm, t]
   ```
 
-  Bidirectional transport constrains bothe the inlet and outlet flow to the provided capacity:
+  Bidirectional transport constrains both the inlet and outlet flow to the provided capacity:
 
   ```math
   \begin{aligned}
@@ -241,7 +241,7 @@ The following standard constraints are implemented for a [`TransmissionMode`](@r
   ```
 
   !!! tip "The function `scale_op_sp`"
-      The function [``scale\_op\_sp(t_{inv}, t)``](@ref EnergyModelsBase.scale_op_sp) calculates the scaling factor between operational and strategic periods.
+      The function [``scale\_op\_sp(t_{inv}, t)``](@extref EnergyModelsBase.scale_op_sp) calculates the scaling factor between operational and strategic periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
 - `constraints_emissions`:

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -76,3 +76,9 @@ emit_resources
 is_bidirectional
 trans_sub
 ```
+
+## [Utility functions](@id lib-int-fun-util)
+
+```@docs
+connected_nodes
+```

--- a/docs/src/library/public/area.md
+++ b/docs/src/library/public/area.md
@@ -27,5 +27,11 @@ availability_node
 limit_resources
 exchange_limit
 exchange_resources
+```
+
+## [Utility functions for `Area` types](@id lib-pub-area-fun_util)
+
+```@docs
 getnodesinarea
+nodes_in_area
 ```

--- a/src/EnergyModelsGeography.jl
+++ b/src/EnergyModelsGeography.jl
@@ -42,7 +42,7 @@ export name, availability_node, limit_resources, exchange_limit, exchange_resour
 export modes, mode_sub, modes_sub, corr_from, corr_to, corr_from_to, modes_of_dir
 
 # Export commonly used functions for extracting fields in `TransmissionMode`s
-export map_trans_resource, exchange_resources
+export map_trans_resource
 export loss, directions, mode_data, consumption_rate, energy_share
 
 end # module

--- a/src/EnergyModelsGeography.jl
+++ b/src/EnergyModelsGeography.jl
@@ -32,12 +32,14 @@ export PipeMode, PipeSimple, PipeLinepackSimple
 # Export the legacy constructor for transmission investment data
 export TransInvData
 
+# Export utility functions
+export getnodesinarea, nodes_in_area
+
 # Export commonly used functions for extracting fields in `Area`s
 export name, availability_node, limit_resources, exchange_limit, exchange_resources
 
 # Export commonly used functions for exctracting fields in `Transmission`s
 export modes, mode_sub, modes_sub, corr_from, corr_to, corr_from_to, modes_of_dir
-export getnodesinarea
 
 # Export commonly used functions for extracting fields in `TransmissionMode`s
 export map_trans_resource, exchange_resources

--- a/src/model.jl
+++ b/src/model.jl
@@ -193,7 +193,7 @@ end
 """
     variables_trans_emission(m, 𝒯, ℳ, 𝒫, modeltype)
 
-Declation of variables for the modeling of tranmission emissions. These variables are only
+Declation of variables for the modeling of transmission emissions. These variables are only
 created for transmission modes where emissions are included. All emission resources that are
 not included for a type are fixed to a value of 0.
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,7 +4,7 @@
 
 Return a vector with all the nodes connected to the central availability node of an area.
 
-# Fields
+# Arguments
 - **`a::Area`**. \n
 - **`links`** is a vector of all links in the model.
 """
@@ -34,4 +34,76 @@ function getnodesinarea(a::Area, links)
         end
     end
     return unique!(nodes)
+end
+
+"""
+    nodes_in_area(a::Area, ℒ::Vector{<:Link}; n_nodes=1000)
+
+Returns a vector of all nodes in area `a` connected through links `ℒ`. The approach is based
+on a breadth-first-search and provides all connected nodes, contrary to the function
+[getnodesinarea](@ref).
+
+# Arguments
+- **`a::Area`** is area that should be evaluated
+- **`ℒ::Vector{<:Link}`** is a vector of links that should be evaluated.
+
+# Keyword arguments
+- **`n_nodes=1000`** the number of nodes added after which the loop is broken. It must be
+  at least equal to the number of nodes in the area `a`.
+"""
+function nodes_in_area(a::Area, ℒ::Vector{<:Link}; n_nodes=1000)
+    av = availability_node(a)
+
+    # Initiate the arrays
+    queue = EMB.Node[av]
+    nodes = EMB.Node[av]
+    links = EMB.Direct[]
+    k = 1
+    while !isempty(queue)
+        # Extract the connected nodes
+        con_nodes, con_links = connected_nodes(queue[1], ℒ, nodes)
+        append!(queue, con_nodes)
+        append!(nodes, con_nodes)
+        append!(links, con_links)
+
+        # Remove the current node from the queue
+        deleteat!(queue, 1)
+
+        # Update the stack overflow protection
+        k += 1
+        if k > n_nodes
+            break
+        end
+    end
+    return nodes, unique(links)
+end
+
+"""
+    connected_nodes(n::EMB.Node, ℒ::Vector{<:Link}, nodes::Vector{EMB.Node})
+
+Returns a vector of all unique nodes connected to node `n` through links `ℒ`.
+The corresponding links are also returned.
+
+# Arguments
+- **`n::EMB.Node`** is the node from which the connections are evaluated.
+- **`ℒ::Vector{<:Link}`** is a vector of links that should be evaluated.
+- **`nodes::Vector{EMB.Node}`** is a vector of nodes that should not be included.
+"""
+function connected_nodes(n::EMB.Node, ℒ::Vector{<:Link}, nodes::Vector{<:EMB.Node})
+    con_nodes = []
+    con_links = []
+
+    # Extract the links which are connecting the node `n`
+    for l ∈ ℒ
+        n_from = l.from
+        n_to = l.to
+        if n_from == n && !(n_to ∈ nodes)
+            push!(con_nodes, n_to)
+            push!(con_links, l)
+        elseif n_to == n && !(n_from ∈ nodes)
+            push!(con_nodes, n_from)
+            push!(con_links, l)
+        end
+    end
+    return unique(con_nodes), con_links
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -8,8 +8,8 @@
     a1 = areas[1]
     a2 = areas[2]
 
-    nodes1 = EMG.getnodesinarea(a1, links)
-    nodes2 = EMG.getnodesinarea(a2, links)
+    nodes1 = getnodesinarea(a1, links)
+    nodes2 = getnodesinarea(a2, links)
 
     @test length(nodes1) == 4
     for i ∈ range(1, 4)
@@ -19,4 +19,92 @@
     for i ∈ range(5, 8)
         @test nodes[i] ∈ nodes2
     end
+end
+
+@testset "Filter nodes by area - new method" begin
+    # Using the same test set as in the original method
+    case, m = bidirectional_case()
+    areas = case[:areas]
+    nodes = case[:nodes]
+    links = case[:links]
+
+    a1 = areas[1]
+    a2 = areas[2]
+
+    nodes1, links1 = nodes_in_area(a1, links)
+    nodes2, links2 = nodes_in_area(a2, links)
+
+    @test length(nodes1) == 4
+    for i ∈ range(1, 4)
+        @test nodes[i] ∈ nodes1
+    end
+    @test length(nodes2) == 4
+    for i ∈ range(5, 8)
+        @test nodes[i] ∈ nodes2
+    end
+
+    # Using a new, large test set
+    function reg(n_nodes::Int, id::String)
+        # Number of random links
+        n_links = 5
+
+        # Define the different resources and their emission intensity in tCO2/MWh
+        NG = ResourceEmit("NG", 0.2)
+        Power = ResourceCarrier("Power", 0.0)
+        products = [NG, Power]
+
+        # Define random nodes
+        av = GeoAvailability("a_" * id * "_0" , products)
+        nodes = EMB.Node[
+            RefNetworkNode(
+                "a_" * id * "_" * string(k),
+                FixedProfile(25),
+                FixedProfile(5.5),          # Variable OPEX in EUR/MWh
+                FixedProfile(0),            # Fixed OPEX in EUR/MW/8h
+                Dict(NG => 2),              # Input to the node with input ratio
+                Dict(Power => 1),           # Output from the node with output ratio
+            ) for k ∈ 1:n_nodes
+        ]
+        append!(nodes, [av])
+
+        # Create links so that all nodes are connected
+        links_1 = [Direct("a_" * id, nodes[k], nodes[k+1]) for k ∈ 1:n_nodes]
+        append!(links_1, [Direct("a_" * id, nodes[1], nodes[end])])
+
+        # Create random links
+        n_rand_1 = rand(1:n_nodes+1, n_links*n_nodes)
+        n_rand_2 = rand(1:n_nodes+1, n_links*n_nodes)
+        links_2 = [Direct("a_" * id, nodes[n_rand_1[k]], nodes[n_rand_2[k]]) for k ∈ 1:n_links*n_nodes]
+        links = vcat(links_1, links_2)
+
+        return nodes, links
+    end
+
+    # Create multiple areas with a variety of nodes
+    a = [100, 200, 600, 20, 5, 150, 900]
+    N_dict = Dict()
+    L_dict = Dict()
+    𝒩 = EMB.Node[]
+    ℒ = EMB.Link[]
+    for (k, val) ∈ enumerate(a)
+        N_dict[k], L_dict[k] = reg(val, string(k))
+        append!(𝒩, N_dict[k])
+        append!(ℒ, L_dict[k])
+    end
+
+    # Evaluate the areas
+    nodes = Dict()
+    links = Dict()
+    for (k, val) ∈ enumerate(a)
+        nodes[k], links[k] = nodes_in_area(
+            RefArea(k, string(k), 10.751, 59.921, N_dict[k][end]),
+            ℒ,
+            n_nodes=length(𝒩));
+    end
+
+    # Test that the correct nodes are extracted
+    @test all(n.id[1:3] == "a_" * string(k) for (k, _) ∈ enumerate(a) for n ∈ nodes[k])
+
+    # Test that the correct links are extracted
+    @test all(l.id[1:3] == "a_" * string(k) for (k, _) ∈ enumerate(a) for l ∈ links[k])
 end


### PR DESCRIPTION
The existing funciton `getnodesinarea` only identifies nodes that are connected to the availability node of an area with a maximum distance of 2 links. This is not really satisfactory. Instead, a new function called `nodes_in_area` is introduced which utilizes an adaptation of a *[breadth-first search](https://en.wikipedia.org/wiki/Breadth-first_search)* to identify the corresponding nodes. 

The function `connected_nodes` could also be migrated to `EnergyModelsBase`, as it provides the user with a functionality to identify all connected nodes and the corresponding links.