### PR TITLE
Incorporation of changes from EnergyModelsBase v0.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Unversioned
 
+### Adjustments to EMB v0.9
+
+* Switched to case structure introduced in EMB.
+* Rewrote most functions to work directly with the new approach.
+* Restructured tests for `Area`s and `TransmissionMode`s based on the new approach.
+
+### Minor updates
+
 * Included a new method for identifying nodes within an area using breadth-first search.
   This method allows for an arbitrary connection of links between a node and the availability node.
 * Minor typo updates in the documentation.

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 EMIExt = "EnergyModelsInvestments"
 
 [compat]
-EnergyModelsBase = "0.8.1"
+EnergyModelsBase = "0.9.0"
 EnergyModelsInvestments = "0.8"
 SparseVariables = "0.7.3"
 JuMP = "1.5"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -62,6 +62,7 @@ makedocs(
                 "Areas"=>"library/public/area.md",
                 "Transmission"=>"library/public/transmission.md",
                 "TransmissionMode"=>"library/public/mode.md",
+                "Case"=>"library/public/case_element.md",
                 "EMI extension"=>"library/public/emi_extension.md",
             ],
             "Internals"=>Any[

--- a/docs/src/area_mode/area.md
+++ b/docs/src/area_mode/area.md
@@ -75,10 +75,10 @@ The variables of [`Area`](@ref)s include:
 
 #### [Constraints](@id area_mode-areas-areas-math-con)
 
-The constraints for areas are calculated within the functions [`constraints_area`](@ref EnergyModelsGeography.constraints_area) and [`create_area`](@ref EnergyModelsGeography.create_area).
-The function [`constraints_area`](@ref EnergyModelsGeography.constraints_area) is the core function as it links the transmission to and from an area with a local energy system while the function [`create_area`](@ref EnergyModelsGeography.create_area) allows for providing additional constraints.
+The constraints for areas are calculated within a new method for the function [`create_area`](@ref EnergyModelsGeography.create_area) and [`constraints_couple`](@ref EnergyModelsBase.constraints_couple).
+The function [`constraints_couple`](@ref EnergyModelsBase.constraints_couple) is the core function as it links the transmission to and from an area with a local energy system while the function [`create_area`](@ref EnergyModelsGeography.create_area) allows for providing additional constraints.
 
-##### [`constraints_area`](@id area_mode-areas-areas-math-con-con)
+##### [`constraints_couple`](@id area_mode-areas-areas-math-con-con)
 
 The overall energy balance is solved within this function.
 We consider two cases:

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -5,6 +5,32 @@ Hence, there are frequently breaking changes occuring, although we plan to keep 
 This document is designed to provide users with information regarding how they have to adjust their models to keep compatibility to the latest changes.
 We will as well implement information regarding the adjustment of extension packages, although this is more difficult due to the vast majority of potential changes.
 
+## [Adjustments from 0.10.x](@id how_to-update-10)
+
+Starting from version 0.11.0, we introduced a new input format to the function `create_model`.
+The original case dictionary is replaced with a new type, [`Case`](@extref EnergyModelsBase.Case).
+We introduced deprecated methods that can be utilized with the original dictionary, but it is advisable to switch to the new type as:
+
+```julia
+# Old structure:
+case = Dict(
+    :areas => Array{Area}(areas),
+    :transmission => Array{Transmission}(transmission),
+    :nodes => Array{EMB.Node}(nodes),
+    :links => Array{Link}(links),
+    :products => products,
+    :T => T,
+)
+
+# New structure:
+case = Case(
+    T,
+    products,
+    [nodes, links, areas, transmissions],
+    [[get_nodes, get_links], [get_areas, get_transmissions]],
+)
+```
+
 ## [Adjustments from 0.9.x](@id how_to-update-09)
 
 ### [Key changes for transmission mode descriptions](@id how_to-update-06-mode)

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -9,7 +9,7 @@ We will as well implement information regarding the adjustment of extension pack
 
 Starting from version 0.11.0, we introduced a new input format to the function `create_model`.
 The original case dictionary is replaced with a new type, [`Case`](@extref EnergyModelsBase.Case).
-We introduced deprecated methods that can be utilized with the original dictionary, but it is advisable to switch to the new type as:
+Backwards-compatible methods are available to use with the original dictionary, however these are deprecated and we advise to switch to the new type::
 
 ```julia
 # Old structure:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,6 +53,7 @@ Pages = [
     "library/public/transmission.md",
     "library/public/mode.md",
     "library/public/emi_extension.md",
+    "library/public/case_element.md",
     ]
 Depth = 1
 ```

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -16,14 +16,11 @@ CurrentModule = EnergyModelsGeography
 create_area
 create_model
 create_transmission_mode
-update_objective(m, 𝒯, ℳ, modeltype::EnergyModel)
-update_total_emissions
 ```
 
 ## [Constraint functions](@id lib-int-fun-con)
 
 ```@docs
-constraints_area
 constraints_capacity
 constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EnergyModel)
 constraints_emission
@@ -31,7 +28,6 @@ constraints_opex_fixed
 constraints_opex_var
 constraints_trans_balance
 constraints_trans_loss
-constraints_transmission
 ```
 
 ## [Compute functions](@id lib-int-fun-comp)
@@ -44,23 +40,14 @@ compute_trans_out
 ## [Variable creation functions](@id lib-int-fun-var)
 
 ```@docs
-variables_area
-variables_trans_capacity
-variables_trans_capex
-variables_trans_emission
-variables_trans_modes
 variables_trans_mode
-variables_trans_opex
 ```
 
 ## [Check functions](@id lib-int-fun-check)
 
 ```@docs
 check_area
-check_case_data
-check_data
 check_mode
-check_time_structure
 check_transmission
 ```
 

--- a/docs/src/library/internals/methods_EMB.md
+++ b/docs/src/library/internals/methods_EMB.md
@@ -9,15 +9,38 @@ Pages = ["methods_EMB.md"]
 ## [Extension methods](@id lib-int-met_emb-ext)
 
 ```@docs
-EnergyModelsBase.create_node
+EMB.create_node
+EMB.objective_operational
+EMB.emissions_operational
+EMB.constraints_elements
+EMB.constraints_couple
+```
+
+## [Variable methods](@id lib-int-met_emb-var)
+
+```@docs
+EMB.variables_capacity
+EMB.variables_flow
+EMB.variables_opex
+EMB.variables_capex(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳, 𝒯, modeltype::EnergyModel)
+EMB.variables_elements
+EMB.variables_element
+EMB.variables_emission
 ```
 
 ## [Field extraction methods](@id lib-int-met_emb-field)
 
 ```@docs
-EnergyModelsBase.capacity
-EnergyModelsBase.inputs
-EnergyModelsBase.outputs
-EnergyModelsBase.opex_fixed
-EnergyModelsBase.opex_var
+EMB.capacity
+EMB.inputs
+EMB.outputs
+EMB.opex_fixed
+EMB.opex_var
+```
+
+## [Check methods](@id lib-int-fun-check)
+
+```@docs
+EMB.check_elements
+EMB.check_time_structure
 ```

--- a/docs/src/library/internals/methods_EMIExt.md
+++ b/docs/src/library/internals/methods_EMIExt.md
@@ -16,9 +16,15 @@ CurrentModule =
 ### [Methods](@id lib-int-EMIext-EMG-met)
 
 ```@docs
-EMG.update_objective(m, 𝒯, ℳ, modeltype::EMB.AbstractInvestmentModel)
 EMG.constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStructure, modeltype::EMB.AbstractInvestmentModel)
-EMG.variables_trans_capex(m, 𝒯, ℳ, modeltype::EMB.AbstractInvestmentModel)
+```
+
+## [EnergyModelsBase](@id lib-int-EMIext-EMB)
+
+### [Methods](@id lib-int-EMIext-EMB-met)
+
+```@docs
+EMB.objective_invest
 ```
 
 ## [EnergyModelsInvestments](@id lib-int-EMIext-EMI)

--- a/docs/src/library/public/case_element.md
+++ b/docs/src/library/public/case_element.md
@@ -1,0 +1,42 @@
+# [Case description](@id lib-pub-case)
+
+## Index
+
+```@index
+Pages = ["case_element.md"]
+```
+
+## [Case type](@id lib-pub-case-case)
+
+The incorporation of the [`AbstractElement`](@extref EnergyModelsBase.AbstractElement)s requires a change to the provided input.
+
+The original design of `EnergyModelsBase` when only considering [`Node`](@extref EnergyModelsBase.Node)s and [`Link`](@extref EnergyModelsBase.Link)s is given by:
+
+```julia
+case = Case(
+    T,
+    products,
+    [nodes, links],
+    [[get_nodes, get_links]],
+)
+```
+
+Including areas and transmission corridors requires to declare the case as
+
+```julia
+case = Case(
+    T,
+    products,
+    [nodes, links, areas, transmissions],
+    [[get_nodes, get_links], [get_areas, get_transmissions]],
+)
+```
+
+that is including the `areas` and `transmissions` vectors in the field `elements` and adding a new vector to the field `couplings` given by the functions to access `areas` and `transmissions` vectors in the field `elements`, `get_areas` and `get_transmissions` as described below
+
+## [Functions for accessing different information](@id lib-pub-links-fun_field)
+
+```@docs
+get_areas
+get_transmissions
+```

--- a/examples/investments.jl
+++ b/examples/investments.jl
@@ -47,9 +47,8 @@ function generate_example_data_geo()
 
     # Create identical areas with index according to input array
     an = Dict()
-    transmission = []
-    nodes = []
-    links = []
+    nodes = EMB.Node[]
+    links = Link[]
     for a_id in area_ids
         n, l = get_sub_system_data_inv(
             a_id,
@@ -154,7 +153,7 @@ function generate_example_data_geo()
         [],
     )
 
-    transmission = [
+    transmissions = [
         Transmission(areas[1], areas[2], [OverheadLine_50MW_12]),
         Transmission(areas[1], areas[3], [OverheadLine_50MW_13]),
         Transmission(areas[2], areas[3], [OverheadLine_50MW_23]),
@@ -169,14 +168,12 @@ function generate_example_data_geo()
     modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.07)
 
 
-    # WIP data structure
-    case = Dict(
-        :areas => Array{Area}(areas),
-        :transmission => Array{Transmission}(transmission),
-        :nodes => Array{EMB.Node}(nodes),
-        :links => Array{Link}(links),
-        :products => products,
-        :T => T,
+    # Input data structure
+    case = Case(
+        T,
+        products,
+        [nodes, links, areas, transmissions],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
     )
     return case, modeltype
 end
@@ -488,7 +485,7 @@ end
 # Generate case data
 case, model = generate_example_data_geo()
 optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
-m = EMG.create_model(case, model)
+m = create_model(case, model)
 set_optimizer(m, optimizer)
 optimize!(m)
 
@@ -496,5 +493,3 @@ solution_summary(m)
 
 # Uncomment to print all the constraints set in the model.
 # print(m)
-
-solution_summary(m)

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -76,8 +76,8 @@ function generate_example_data()
 
     # Create identical areas with index according to the input array
     an           = Dict()
-    nodes        = []
-    links        = []
+    nodes        = EMB.Node[]
+    links        = Link[]
     for a_id in area_ids
         n, l = get_sub_system_data(
             a_id,
@@ -132,7 +132,7 @@ function generate_example_data()
     SD_OverheadLine_50MW  = RefStatic("SD_PowerLine_50", Power, cap_ohl, loss, opex_var, opex_fix, 2)
 
     # Create the different transmission corridors between the individual areas
-    transmission = [
+    transmissions = [
                 Transmission(areas[1], areas[2], [OB_OverheadLine_50MW]),
                 Transmission(areas[1], areas[3], [OT_OverheadLine_50MW]),
                 Transmission(areas[1], areas[5], [OK_OverheadLine_50MW]),
@@ -144,15 +144,13 @@ function generate_example_data()
                 Transmission(areas[6], areas[7], [SD_OverheadLine_50MW]),
     ]
 
-    # WIP data structure
-    case = Dict(
-                :areas          => Array{Area}(areas),
-                :transmission   => Array{Transmission}(transmission),
-                :nodes          => Array{EMB.Node}(nodes),
-                :links          => Array{Link}(links),
-                :products       => products,
-                :T              => T,
-                )
+    # Input data structure
+    case = Case(
+        T,
+        products,
+        [nodes, links, areas, transmissions],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
+    )
     return case, model
 end
 
@@ -269,7 +267,7 @@ end
 # Generate the case and model data and run the model
 case, model = generate_example_data()
 optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
-m = EMG.create_model(case, model)
+m = create_model(case, model)
 set_optimizer(m, optimizer)
 optimize!(m)
 

--- a/ext/EMIExt/EMIExt.jl
+++ b/ext/EMIExt/EMIExt.jl
@@ -15,7 +15,6 @@ const TS = TimeStruct
 include("model.jl")
 include("legacy_constructor.jl")
 
-
 """
     EMI.has_investment(tm::EMG.TransmissionMode)
 

--- a/ext/EMIExt/model.jl
+++ b/ext/EMIExt/model.jl
@@ -12,7 +12,7 @@ They are not discounted and do not take the duration of the investment periods i
 
 The expression includes the sum of the capital expenditures for all [`TransmissionMode`](@ref)s
 within the [`Transmission`](@ref) corridors whose method of the function
-[`has_investment`](@extref EnergyModelsBase.has_investment) returns true.
+[`has_investment`](@extref EnergyModelsInvestments.has_investment) returns true.
 """
 function EMB.objective_invest(
     m,

--- a/src/EnergyModelsGeography.jl
+++ b/src/EnergyModelsGeography.jl
@@ -9,18 +9,23 @@ module EnergyModelsGeography
 using Base: Float64
 using JuMP
 using EnergyModelsBase; const EMB = EnergyModelsBase
-using TimeStruct
+using TimeStruct; const TS = TimeStruct
 
 include(joinpath("structures", "area.jl"))
 include(joinpath("structures", "mode.jl"))
 include(joinpath("structures", "transmission.jl"))
 include(joinpath("structures", "data.jl"))
+include(joinpath("structures", "case.jl"))
+
 include("checks.jl")
 include("model.jl")
 include("constraint_functions.jl")
 include("compute_functions.jl")
 include("legacy_constructors.jl")
 include("utils.jl")
+
+# Export the functions for the case type
+export get_areas, get_transmissions
 
 # Export the invidiual types and composite types
 export Area, RefArea, LimitedExchangeArea

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -6,7 +6,7 @@
 !!! note "Area methods"
     All areas are checked through the functions
     - [`check_area`](@ref) to identify problematic input,
-    - [`check_time_structure`](@extref EnergyModelsbase.check_time_structure) to identify
+    - [`check_time_structure`](@extref EnergyModelsBase.check_time_structure) to identify
       time profiles at the highest level that are not equivalent to the provided timestructure.
 
     In addition, all areas are directly checked
@@ -18,12 +18,12 @@
 !!! note "Transmission methods"
     All transmission corridors are checked through the functions
     - [`check_transmission`](@ref) to identify problematic input,
-    - [`check_time_structure`](@extref EnergyModelsbase.check_time_structure) to identify
+    - [`check_time_structure`](@extref EnergyModelsBase.check_time_structure) to identify
       time profiles at the highest level that are not equivalent to the provided timestructure.
 
     The individual transmission modes of a corridorare checked through the functions
     - [`check_mode`](@ref) to identify problematic input and
-    - [`check_time_structure`](@extref EnergyModelsbase.check_time_structure) to identify
+    - [`check_time_structure`](@extref EnergyModelsBase.check_time_structure) to identify
       time profiles at the highest level that are not equivalent to the provided timestructure.
 
     In addition, all transmission corridors are directly checked to have in the fields
@@ -143,7 +143,7 @@ function check_mode(l::TransmissionMode, 𝒯, modeltype::EnergyModel, check_tim
 end
 
 """
-    check_time_structure(m::TransmissionMode, 𝒯)
+    EMB.check_time_structure(m::TransmissionMode, 𝒯)
 
 Check that all fields of a `TransmissionMode` that are of type `TimeProfile` correspond to
 the time structure `𝒯`.

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -1,112 +1,145 @@
 
 """
-    check_data(case, modeltype, check_timeprofiles::Bool)
+    EMB.check_elements(log_by_element, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    EMB.check_elements(log_by_element, ℒᵗʳᵃⁿˢ::Vector{<:Tranmission}, v, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
-Check if the case data is consistent. Use the `@assert_or_log` macro when testing.
-Currently, not checking data except that the case dictionary follows the required structure.
+!!! note "Area methods"
+    All areas are checked through the functions
+    - [`check_area`](@ref) to identify problematic input,
+    - [`check_time_structure`](@extref EnergyModelsbase.check_time_structure) to identify
+      time profiles at the highest level that are not equivalent to the provided timestructure.
+
+    In addition, all areas are directly checked
+    - that the node returned by the function [`availability_node`](@ref) is within the Node
+      vector,
+    - that the availability node is a [`GeoAvailability`](@ref) node, and
+    - the exchange resources are within the resources of the [`GeoAvailability`](@ref) node.
+
+!!! note "Transmission methods"
+    All transmission corridors are checked through the functions
+    - [`check_transmission`](@ref) to identify problematic input,
+    - [`check_time_structure`](@extref EnergyModelsbase.check_time_structure) to identify
+      time profiles at the highest level that are not equivalent to the provided timestructure.
+
+    The individual transmission modes of a corridorare checked through the functions
+    - [`check_mode`](@ref) to identify problematic input and
+    - [`check_time_structure`](@extref EnergyModelsbase.check_time_structure) to identify
+      time profiles at the highest level that are not equivalent to the provided timestructure.
+
+    In addition, all transmission corridors are directly checked to have in the fields
+    `:from` and `:to` nodes that are present in the Area vector as extracted through the
+    function [`get_areas`](@ref).
 """
-function check_data(case, modeltype, check_timeprofiles::Bool)
-
-    global EMB.logs = []
-    log_by_element = Dict()
-
-    # Check the case data. If the case data is not in the correct format, the overall check
-    # is cancelled as extractions would not be possible
-    check_case_data(case)
-    log_by_element["Case data"] = EMB.logs
-    if EMB.ASSERTS_AS_LOG
-        EMB.compile_logs(case, log_by_element)
-    end
-
-    𝒜 = case[:areas]
-    ℒᵗʳᵃⁿˢ = case[:transmission]
-    𝒫 = case[:products]
-    𝒯 = case[:T]
+function EMB.check_elements(
+    log_by_element,
+    𝒜::Vector{<:Area},
+    𝒳ᵛᵉᶜ,
+    𝒯,
+    modeltype::EnergyModel,
+    check_timeprofiles::Bool
+)
+    # Extract the required subsets
+    𝒩  = get_nodes(𝒳ᵛᵉᶜ)
+    ℒᵗʳᵃⁿˢ = get_transmissions(𝒳ᵛᵉᶜ)
 
     for a ∈ 𝒜
-        check_area(a, 𝒯, 𝒫, modeltype, check_timeprofiles)
-        # Put all log messages that emerged during the check, in a dictionary with the
-        # area as key.
-        log_by_element[a] = EMB.logs
-    end
-    for l ∈ ℒᵗʳᵃⁿˢ
-        check_transmission(l, 𝒯, 𝒫, modeltype, check_timeprofiles)
+        # Empty the logs list before each check.
+        global EMB.logs = []
 
-        ℳ = modes(l)
-        for m ∈ ℳ
-            check_mode(m, 𝒯, 𝒫, modeltype, check_timeprofiles)
-            if check_timeprofiles
-                check_time_structure(m, 𝒯)
-            end
-        # Put all log messages that emerged during the check, in a dictionary with the
-        # corridor as key.
-        log_by_element[l] = EMB.logs
-        end
-    end
-
-    if EMB.ASSERTS_AS_LOG
-        EMB.compile_logs(case, log_by_element)
-    end
-end
-
-"""
-    check_case_data(case)
-
-Checks the `case` dictionary is in the correct format. The function is only checking the
-new, additional data as we do not yet consider dispatch on the case data.
-
-## Checks
-- The dictionary requires the keys `:areas` and `:transmission`.
-- The individual keys are of the correct type, that is
-  - `:areas::Area` and
-  - `:transmission::Vector{<:Transmission}`.
-"""
-function check_case_data(case)
-
-    case_keys = [:areas, :transmission]
-    key_map = Dict(
-        :areas => Vector{<:Area},
-        :transmission => Vector{<:Transmission},
-    )
-    for key ∈ case_keys
+        # Check the availability node of the area
+        av = availability_node(a)
         @assert_or_log(
-            haskey(case, key),
-            "The `case` dictionary requires the key `:" * string(key) * "` which is " *
-            "not included."
+            av ∈ 𝒩,
+            "The node accessed through the function `availability_node` is not included in " *
+            "the Node vector. As a consequence, the area would not be utilized in the model."
         )
-        if haskey(case, key)
+        @assert_or_log(
+            isa(av, GeoAvailability),
+            "The node accessed through the function `availability_node` is not a `GeoAvailability` " *
+            "node. As a consequence, the area cannot exchange resources with other areas."
+        )
+        for p ∈ exchange_resources(ℒᵗʳᵃⁿˢ, a)
             @assert_or_log(
-                isa(case[key], key_map[key]),
-                "The key `" * string(key) * "` in the `case` dictionary contains " *
-                "other types than the allowed."
+                p ∈ inputs(av) && p ∈ outputs(av),
+                "The exchange resource `$(p)`` is not included in inputs or outputs resources of " *
+                "the `GeoAvailability` node resulting an error in model construction."
             )
         end
+
+        # Check the area and the time structure
+        check_area(a, 𝒯, modeltype, check_timeprofiles)
+        check_timeprofiles && EMB.check_time_structure(a, 𝒯)
+        # Put all log messages that emerged during the check, in a dictionary with the node as key.
+        log_by_element[a] = EMB.logs
+    end
+end
+function EMB.check_elements(
+    log_by_element,
+    ℒᵗʳᵃⁿˢ::Vector{<:Transmission},
+    𝒳ᵛᵉᶜ,
+    𝒯,
+    modeltype::EnergyModel,
+    check_timeprofiles::Bool
+)
+    # Extract the required subsets
+    𝒜 = get_areas(𝒳ᵛᵉᶜ)
+
+    for l ∈ ℒᵗʳᵃⁿˢ
+        # Empty the logs list before each check.
+        global EMB.logs = []
+
+        # Check the connections of the transmission corridor
+        @assert_or_log(
+            l.from ∈ 𝒜,
+            "The area in the field `:from` is not included in the Area vector. As a consequence, " *
+            "the transmission corridor would not be utilized in the model."
+        )
+        @assert_or_log(
+            l.to ∈ 𝒜,
+            "The area in the field `:to` is not included in the Area vector. As a consequence, " *
+            "the transmission corridor would not be utilized in the model."
+        )
+
+        # Check the transmission corridor and the time structure
+        check_transmission(l, 𝒯, modeltype, check_timeprofiles)
+        check_timeprofiles && EMB.check_time_structure(l, 𝒯)
+
+        # Check all individual trasmission modes
+        ℳ = modes(l)
+        for m ∈ ℳ
+            check_mode(m, 𝒯, modeltype, check_timeprofiles)
+            check_timeprofiles && EMB.check_time_structure(m, 𝒯)
+        end
+
+        # Put all log messages that emerged during the check, in a dictionary with the
+        # transmission corridor as key.
+        log_by_element[l] = EMB.logs
     end
 end
 
 """
-    check_area(a::Area, 𝒯, 𝒫, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_area(a::Area, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
 Check that the fields of an `Area` corresponds to required structure.
 """
-function check_area(a::Area, 𝒯, 𝒫, modeltype::EnergyModel, check_timeprofiles::Bool)
+function check_area(a::Area, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 end
 
 """
-    check_transmission(l::Transmission, 𝒯, 𝒫, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_transmission(l::Transmission, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
 Check that the fields of a `Transmission` corridor corresponds to required structure.
 """
-function check_transmission(l::Transmission, 𝒯, 𝒫, modeltype::EnergyModel, check_timeprofiles::Bool)
+function check_transmission(l::Transmission, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 end
 
 
 """
-    check_mode(m::TransmissionMode, 𝒯, 𝒫, modeltype::EnergyModel, check_timeprofiles::Bool)
+    check_mode(m::TransmissionMode, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
 Check that the fields of a `TransmissionMode` corresponds to required structure.
 """
-function check_mode(l::TransmissionMode, 𝒯, 𝒫, modeltype::EnergyModel, check_timeprofiles::Bool)
+function check_mode(l::TransmissionMode, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 end
 
 """
@@ -115,7 +148,7 @@ end
 Check that all fields of a `TransmissionMode` that are of type `TimeProfile` correspond to
 the time structure `𝒯`.
 """
-function check_time_structure(m::TransmissionMode, 𝒯)
+function EMB.check_time_structure(m::TransmissionMode, 𝒯)
     for fieldname ∈ fieldnames(typeof(m))
         value = getfield(m, fieldname)
         if isa(value, TimeProfile)

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -1,7 +1,7 @@
 
 """
     EMB.check_elements(log_by_element, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
-    EMB.check_elements(log_by_element, ℒᵗʳᵃⁿˢ::Vector{<:Tranmission}, v, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    EMB.check_elements(log_by_element, ℒᵗʳᵃⁿˢ::Vector{<:Tranmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
 !!! note "Area methods"
     All areas are checked through the functions

--- a/src/model.jl
+++ b/src/model.jl
@@ -382,7 +382,9 @@ end
     EMB.create_node(m, n::GeoAvailability, 𝒯, 𝒫, modeltype::EnergyModel)
 
 Set all constraints for a [`GeoAvailability`](@ref). The energy balance is handled in the
-function [`constraints_area`](@ref). Hence, no constraints are added in this function.
+function [`constraints_elements`](@ref EnergyModelsBase.constraints_elements).
+
+Hence, no constraints are added in this function.
 """
 function EMB.create_node(m, n::GeoAvailability, 𝒯, 𝒫, modeltype::EnergyModel) end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -11,12 +11,6 @@ function create_model(
     check_timeprofiles::Bool=true,
     check_any_data::Bool = true,
 )
-    @debug "Construct model"
-    # Call of the basic model
-    if check_any_data
-        check_data(case, modeltype, check_timeprofiles)
-    end
-
     case_new = Case(
         case[:T],
         case[:products],

--- a/src/model.jl
+++ b/src/model.jl
@@ -382,7 +382,7 @@ end
     EMB.create_node(m, n::GeoAvailability, 𝒯, 𝒫, modeltype::EnergyModel)
 
 Set all constraints for a [`GeoAvailability`](@ref). The energy balance is handled in the
-function [`constraints_elements`](@ref EnergyModelsBase.constraints_elements).
+function [`constraints_couple`](@ref EnergyModelsBase.constraints_couple).
 
 Hence, no constraints are added in this function.
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,28 +1,11 @@
 """
-    create_model(case, modeltype::EnergyModel, m::JuMP.Model; check_timeprofiles::Bool=true)
+    create_model(case::Dict, modeltype::EnergyModel, m::JuMP.Model; check_timeprofiles::Bool=true)
 
-Create the model and call all required functions.
-
-## Input
-- `case` - The case dictionary requiring the keys `:T`, `:nodes`, `:links`, `products` as
-  it is the case for standard `EnergyModelsBase` models. In addition, the keys `:areas` and
-  `:transmission` are required for extending the existing model.
-  If the input is not provided in the correct form, the checks will identify the problem.
-- `modeltype::EnergyModel` - Used modeltype, that is a subtype of the type `EnergyModel`.
-- `m` - the empty `JuMP.Model` instance. If it is not provided, then it is assumed that the
-  input is a standard `JuMP.Model`.
-
-## Conditional input
-- `check_timeprofiles::Bool=true` - A boolean indicator whether the time profiles of the
-  individual nodes should be checked or not. It is advised to not deactivate the check,
-  except if you are testing new components. It may lead to unexpected behaviour and
-  potential inconsistencies in the input data, if the time profiles are not checked.
-- `check_any_data::Bool=true` - A boolean indicator whether the input data is checked or not.
-  It is advised to not deactivate the check, except if you are testing new features.
-  It may lead to unexpected behaviour and even infeasible models.
+Create the model and call all required functions. This method is a deprecated method and
+should no longer be called.
 """
 function create_model(
-    case,
+    case::Dict,
     modeltype::EnergyModel,
     m::JuMP.Model;
     check_timeprofiles::Bool=true,
@@ -30,42 +13,20 @@ function create_model(
 )
     @debug "Construct model"
     # Call of the basic model
-    m = EMB.create_model(case, modeltype, m; check_timeprofiles, check_any_data)
     if check_any_data
         check_data(case, modeltype, check_timeprofiles)
     end
 
-    # Data structure
-    𝒜 = case[:areas]
-    ℒᵗʳᵃⁿˢ = case[:transmission]
-    𝒫 = case[:products]
-    𝒯 = case[:T]
-
-    # Vector of all `TransmissionMode`s in the corridors
-    ℳ = modes(ℒᵗʳᵃⁿˢ)
-
-    # Declaration of variables foir areas and transmission corridors
-    variables_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, modeltype)
-    variables_trans_capex(m, 𝒯, ℳ, modeltype)
-    variables_trans_opex(m, 𝒯, ℳ, modeltype)
-    variables_trans_capacity(m, 𝒯, ℳ, modeltype)
-    variables_trans_modes(m, 𝒯, ℳ, modeltype)
-    variables_trans_emission(m, 𝒯, ℳ, 𝒫, modeltype)
-
-    # Construction of constraints for areas and transmission corridors
-    constraints_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, 𝒫, modeltype)
-    constraints_transmission(m, 𝒯, ℳ, modeltype)
-
-    # Updates the global constraint on total emissions
-    update_total_emissions(m, 𝒯, ℳ, 𝒫, modeltype)
-
-    # Updates the objective function
-    update_objective(m, 𝒯, ℳ, modeltype)
-
-    return m
+    case_new = Case(
+        case[:T],
+        case[:products],
+        [case[:nodes], case[:links], case[:areas], case[:transmission]],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
+    )
+    return EMB.create_model(case_new, modeltype, m; check_timeprofiles, check_any_data)
 end
 function create_model(
-    case,
+    case::Dict,
     modeltype::EnergyModel;
     check_timeprofiles::Bool = true,
     check_any_data::Bool = true,
@@ -75,61 +36,153 @@ function create_model(
 end
 
 """
-    variables_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, modeltype::EnergyModel)
+    EMB.variables_capacity(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    EMB.variables_capacity(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 
-Declaration of a variable `:area_exchange` to track how much energy is exchanged from an
-area for all operational periods `t ∈ 𝒯`. The variable is only declared for resources that
-are exchanged from a given area.
+Declaration of different capacity variables for the element type introduced in
+`EnergyModelsGeography`. Due to the design of the package, the individual `TransmissionMode`s
+must be extracted now in each package
+
+!!! tip "Transmission variables"
+    The capacity variables are only created for [`TransmissionMode`](@ref)s and not
+    [`Transmission`](@ref) corridors. The created variable is
+
+    - `trans_cap[tm, t]` is the installed capacity of transmission mode `tm` in operational
+      period `t`.
+
+!!! note "Area variables"
+    No variables are added
 """
-function variables_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, modeltype::EnergyModel)
+function EMB.variables_capacity(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    ℳ = modes(ℒᵗʳᵃⁿˢ)
+    @variable(m, trans_cap[ℳ, 𝒯] >= 0)
+end
+function EMB.variables_capacity(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel) end
+
+"""
+    EMB.variables_flow(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    EMB.variables_flow(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+
+Declaration of flow OPEX variables for the element types introduced in
+`EnergyModelsGeography`. `EnergyModelsGeography` introduces two elements for an energy system, and
+hence, provides the user with two individual methods:
+
+!!! tip "Transmission variables"
+    The capacity variables are only created for [`TransmissionMode`](@ref)s and not
+    [`Transmission`](@ref) corridors. The created variables are
+
+    - `trans_in[tm, t]` is the flow _**into**_ mode `tm` in operational period `t`. The inflow
+      resources of transmission mode `m` are extracted using the function [`inputs`](@ref).
+    - `trans_out[tm, t]` is the flow _**from**_ mode `tm` in operational period `t`. The outflow
+      resources of transmission mode `m` are extracted using the function [`outputs`](@ref).
+
+!!! note "Area variables"
+    - `area_exchange[a, t, p]` is the exchange of resource `p` by area `a` in operational
+      period `t`. The exchange resources are extracted using the function
+      [`exchange_resources`](@ref)
+"""
+function EMB.variables_flow(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    # Extract the individual transmission modes
+    ℳ = modes(ℒᵗʳᵃⁿˢ)
+
+    # Create the transmission mode flow variables
+    @variable(m, trans_in[ℳ, 𝒯])
+    @variable(m, trans_out[ℳ, 𝒯])
+end
+function EMB.variables_flow(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    ℒᵗʳᵃⁿˢ = get_transmissions(𝒳ᵛᵉᶜ)
     @variable(m, area_exchange[a ∈ 𝒜, 𝒯, p ∈ exchange_resources(ℒᵗʳᵃⁿˢ, a)])
 end
 
 """
-    variables_trans_capex(m, 𝒯, ℳ, modeltype::EnergyModel)
+    EMB.variables_opex(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    EMB.variables_opex(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+
+Declaration of different OPEX variables for the element types introduced in
+`EnergyModelsGeography`. Although `EnergyModelsGeography` introduces two elements,
+only `ℒᵗʳᵃⁿˢ::Vector{Transmission}` requires operational expense variables.
+
+!!! note "Transmission variables"
+    The operational expenses variables are only created for [`TransmissionMode`](@ref)s and
+    not [`Transmission`](@ref) corridors. The created variables are
+
+    - `trans_opex_var[tm, t_inv]` are the variable operating expenses of node `n` in investment
+      period `t_inv`. The values can be negative to account for revenue streams
+    - `trans_opex_fixed[tm, t_inv]` are the fixed operating expenses of node `n` in investment
+      period `t_inv`.
+
+!!! note "Area variables"
+    No variables are added
+"""
+function EMB.variables_opex(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    # Extract the individual transmission modes and strategic periods
+    ℳ = modes(ℒᵗʳᵃⁿˢ)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+
+    # Create the transmission mode opex variables
+    @variable(m, trans_opex_var[ℳ, 𝒯ᴵⁿᵛ])
+    @variable(m, trans_opex_fixed[ℳ, 𝒯ᴵⁿᵛ] >= 0)
+end
+function EMB.variables_opex(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel) end
+
+"""
+    EMB.variables_capex(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
+    EMB.variables_capex(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 
 Create variables for the capital costs for the investments in transmission.
 Empty function to allow for multiple dispatch in the `EnergyModelsInvestment` package.
 """
-function variables_trans_capex(m, 𝒯, ℳ, modeltype::EnergyModel) end
+function EMB.variables_capex(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel) end
+function EMB.variables_capex(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel) end
 
 """
-    variables_trans_opex(m, 𝒯, ℳ, modeltype::EnergyModel)
+    EMB.variables_emission(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 
-Declaration of variables for the operational costs (`:trans_opex_var` and
-`:trans_opex_fixed`) of the tranmission modes.
+Declaration of an emission variables for the element types introduced in `EnergyModelsGeography`.
+Although `EnergyModelsGeography` introduces two elements, only `ℒᵗʳᵃⁿˢ::Vector{Transmission}`
+requires an emission variable.
+
+Declation of variables for the modeling of transmission emissions. These variables are only
+created for transmission modes where emissions are included. All emission resources that are
+not included for a type are fixed to a value of 0.
+
+!!! note "Transmission variables"
+    - `emissions_trans[tm, t, p_em]` emissions of [`ResourceEmit`](@extref EnergyModelsBase.ResourceEmit)
+      of transmission mode `tm` in operational period `t`. The variable is fixed to 0 for
+      `ResourceEmit` that are not within the vector returned by the function [`emit_resources`](@ref).
+
+!!! note "Area variables"
+    No variables are added
 """
-function variables_trans_opex(m, 𝒯, ℳ, modeltype::EnergyModel)
-    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+function EMB.variables_emission(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
+    ℳ = modes(ℒᵗʳᵃⁿˢ)
+    ℳᵉᵐ = filter(m -> has_emissions(m), ℳ)
+    𝒫ᵉᵐ  = EMB.res_sub(𝒫, ResourceEmit)
 
-    @variable(m, trans_opex_var[ℳ, 𝒯ᴵⁿᵛ])
-    @variable(m, trans_opex_fixed[ℳ, 𝒯ᴵⁿᵛ] >= 0)
+    @variable(m, emissions_trans[ℳᵉᵐ, 𝒯, 𝒫ᵉᵐ] >= 0)
+
+    # Fix of unused emission variables to avoid free variables
+    for tm ∈ ℳᵉᵐ, t ∈ 𝒯, p_em ∈ setdiff(𝒫ᵉᵐ, emit_resources(tm))
+        fix(m[:emissions_trans][tm, t, p_em], 0; force = true)
+    end
 end
+function EMB.variables_emission(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel) end
 
 """
-    variables_trans_capacity(m, 𝒯, ℳ, modeltype::EnergyModel)
+    EMB.variables_elements(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 
-Declaration of variables for tracking how much of installed transmision capacity is used in
-all operational periods `t ∈ 𝒯` of the tranmission modes.
-"""
-function variables_trans_capacity(m, 𝒯, ℳ, modeltype::EnergyModel)
-
-    @variable(m, trans_cap[ℳ, 𝒯] >= 0)
-end
-
-"""
-    variables_trans_modes(m, 𝒯, ℳ, modeltype::EnergyModel)
-
-Loop through all `TransmissionMode` types and create variables specific to each type.
-This is done by calling the method [`variables_trans_mode`](@ref) on all modes of each type.
+Loop through all `TransmissionMode` types present in `ℒᵗʳᵃⁿˢ::Vector{Transmission}` and
+create variables specific to each type. This is done by calling the method
+[`variables_trans_mode`](@ref) on all modes of each type.
 
 The `TransmissionMode` type representing the widest category will be called first. That is,
 `variables_trans_mode` will be called on a `TransmissionMode` before it is called on
 `PipeMode`.
 """
-function variables_trans_modes(m, 𝒯, ℳ, modeltype::EnergyModel)
+function EMB.variables_elements(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒯, modeltype::EnergyModel)
 
-    # Vector of the unique node types in 𝒩.
+    ℳ = modes(ℒᵗʳᵃⁿˢ)
+    # Vector of the unique transmission mode types in ℳ.
     mode_composite_types = unique(map(tm -> typeof(tm), ℳ))
     # Get all `TransmissionMode`-types in the type-hierarchy that the transmission modes
     # ℳ represents.
@@ -160,8 +213,6 @@ Default fallback method when no function is defined for a [`TransmissionMode`](@
 It introduces the variables that are required in all `TransmissionMode`s.
 
 These variables are:
-* `:trans_in` - inlet flow to transmission mode
-* `:trans_out` - outlet flow from a transmission mode
 * `:trans_loss` - loss during transmission
 * `:trans_loss_neg` - negative loss during transmission, helper variable if bidirectional
   transport is possible
@@ -170,13 +221,11 @@ These variables are:
 """
 function variables_trans_mode(m, 𝒯, ℳˢᵘᵇ::Vector{<:TransmissionMode}, modeltype::EnergyModel)
 
-    ℳ2 = modes_of_dir(ℳˢᵘᵇ, 2)
+    ℳ₂ = modes_of_dir(ℳˢᵘᵇ, 2)
 
-    @variable(m, trans_in[ℳˢᵘᵇ, 𝒯])
-    @variable(m, trans_out[ℳˢᵘᵇ, 𝒯])
     @variable(m, trans_loss[ℳˢᵘᵇ, 𝒯] >= 0)
-    @variable(m, trans_neg[ℳ2, 𝒯] >= 0)
-    @variable(m, trans_pos[ℳ2, 𝒯] >= 0)
+    @variable(m, trans_neg[ℳ₂, 𝒯] >= 0)
+    @variable(m, trans_pos[ℳ₂, 𝒯] >= 0)
 end
 
 """
@@ -191,36 +240,56 @@ function variables_trans_mode(m, 𝒯, ℳᴸᴾ::Vector{<:PipeLinepackSimple}, 
 end
 
 """
-    variables_trans_emission(m, 𝒯, ℳ, 𝒫, modeltype)
+    variables_element(m, 𝒜ˢᵘᵇ::Vector{<:Area}, 𝒯, modeltype::EnergyModel)
 
-Declation of variables for the modeling of transmission emissions. These variables are only
-created for transmission modes where emissions are included. All emission resources that are
-not included for a type are fixed to a value of 0.
-
-The emission variables are differentiated in:
-* `:emissions_trans` - emissions of a transmission mode `tm` in operational period `t`.
+Default fallback method for a vector of elements if no other method is defined for a given
+vector type.
 """
-function variables_trans_emission(m, 𝒯, ℳ, 𝒫, modeltype)
-    ℳᵉᵐ = filter(m -> has_emissions(m), ℳ)
-    𝒫ᵉᵐ  = EMB.res_sub(𝒫, ResourceEmit)
+function EMB.variables_element(m, 𝒜ˢᵘᵇ::Vector{<:Area}, 𝒯, modeltype::EnergyModel) end
 
-    @variable(m, emissions_trans[ℳᵉᵐ, 𝒯, 𝒫ᵉᵐ] >= 0)
+"""
+    EMB.constraints_elements(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
+    EMB.constraints_elements(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
 
-    # Fix of unused emission variables to avoid free variables
-    for tm ∈ ℳᵉᵐ, t ∈ 𝒯, p_em ∈ setdiff(𝒫ᵉᵐ, emit_resources(tm))
-        fix(m[:emissions_trans][tm, t, p_em], 0; force = true)
+Loop through all entries of the elements vector and call a subfunction for creating the
+internal constraints of the entries of the elements vector.
+
+`EnergyModelsGeography` provides the user with two element types, [`Area`](@ref) and
+[`Trasnmission`]:
+
+- `Area` - the subfunction is [`create_area`](@ref).
+- `Transmission` - the subfunction is [`create_transmission_mode`](@ref) and called for all
+  [`TransmissionMode`](@ref)s within `ℒᵗʳᵃⁿˢ`.
+"""
+function EMB.constraints_elements(m, 𝒜::Vector{<:Area}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
+    ℒᵗʳᵃⁿˢ = get_transmissions(𝒳ᵛᵉᶜ)
+    for a ∈ 𝒜
+        create_area(m, a, 𝒯, ℒᵗʳᵃⁿˢ, modeltype)
+    end
+end
+function EMB.constraints_elements(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳ᵛᵉᶜ, 𝒫, 𝒯, modeltype::EnergyModel)
+    for tm ∈ modes(ℒᵗʳᵃⁿˢ)
+        create_transmission_mode(m, tm, 𝒯, modeltype)
     end
 end
 
 """
-    constraints_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, 𝒫, modeltype::EnergyModel)
+    EMB.constraints_couple(m, 𝒜::Vector{<:Area}, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒫, 𝒯, modeltype::EnergyModel)
+    EMB.constraints_couple(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒜::Vector{<:Area}, 𝒫, 𝒯, modeltype::EnergyModel)
 
-Function for creating constraints for the energy balances within an area for each resource
-using the [`GeoAvailability`](@ref) node. It keeps track of the exchange with other areas
-through the variable `:area_exchange` and the functions [`compute_trans_in`](@ref) and
-[`compute_trans_out`](@ref).
+Create the new couple constraints in `EnergyModelsGeography`.
+
+The couple constraints are utilizing the variables `:flow_in` and `:flow_out` in combination
+with `:area_exchange` for solving the energy balance on an [`Area`](@ref) level for the
+respective [`GeoAvailability`](@ref) node.
+
+The couple is achieved through the variable `:area_exchange` which is is calculated through
+the functions [`compute_trans_in`](@ref) and [`compute_trans_out`](@ref).
+
+As a consequence, each [`Area`](@ref) can be coupled with multiple [`Transmission`](@ref)
+corridors but each [`Transmission`](@ref) corridor can only be coupled to two [`Area`](@ref)s.
 """
-function constraints_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, 𝒫, modeltype::EnergyModel)
+function EMB.constraints_couple(m, 𝒜::Vector{<:Area}, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒫, 𝒯, modeltype::EnergyModel)
     for a ∈ 𝒜
         # Declaration of the required subsets.
         n = availability_node(a)
@@ -245,17 +314,81 @@ function constraints_area(m, 𝒜, 𝒯, ℒᵗʳᵃⁿˢ, 𝒫, modeltype::Ener
             ==
             sum(compute_trans_out(m, t, p, tm) for tm ∈ modes(ℒᵗᵒ))
         )
-
-        # Limit area exchange
-        create_area(m, a, 𝒯, ℒᵗʳᵃⁿˢ, modeltype)
     end
+end
+function EMB.constraints_couple(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒜::Vector{<:Area}, 𝒫, 𝒯, modeltype::EnergyModel)
+    return constraints_couple(m, 𝒜, ℒᵗʳᵃⁿˢ, 𝒫, 𝒯, modeltype)
+end
+
+"""
+    EMB.emissions_operational(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒫ᵉᵐ, 𝒯, modeltype::EnergyModel)
+
+Create JuMP expressions indexed over the operational periods `𝒯` for different elements.
+The expressions correspond to the total emissions of a given type.
+
+By default, emissions expressions are included for:
+- `𝒳 = ℒᵗʳᵃⁿˢ::Vector{Transmission}`. In the case of a vector of transmission coriddors, the
+  function returns the sum of the emissions of all modes whose method of the function
+  [`has_emissions`](@ref) returns true.
+- `𝒳 = 𝒜::Vector{<:Area}`. In the case of a vector of areas, the method returns returns a
+  value of 0 for all operational periods and emission resources.
+"""
+function EMB.emissions_operational(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒫ᵉᵐ, 𝒯, modeltype::EnergyModel)
+    # Declaration of the required subsets
+    ℳ = modes(ℒᵗʳᵃⁿˢ)
+    ℳᵉᵐ = filter(m -> has_emissions(m), ℳ)
+
+    return @expression(m, [t ∈ 𝒯, p ∈ 𝒫ᵉᵐ],
+        sum(m[:emissions_trans][tm, t, p] for tm ∈ ℳᵉᵐ)
+    )
+end
+function EMB.emissions_operational(m,  𝒜::Vector{<:Area}, 𝒫ᵉᵐ, 𝒯, modeltype::EnergyModel)
+    return @expression(m, [t ∈ 𝒯, p ∈ 𝒫ᵉᵐ], 0)
+end
+
+"""
+    EMB.objective_operational(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::EnergyModel)
+    EMB.objective_operational(m, 𝒜::Vector{<:Area}, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, modeltype::EnergyModel)
+
+Create JuMP expressions indexed over the investment periods `𝒯ᴵⁿᵛ` for different elements.
+The expressions correspond to the operational expenses of the different elements.
+The expressions are not discounted and do not take the duration of the investment periods
+into account.
+
+By default, objective expressions are included for:
+- `𝒳 = ℒᵗʳᵃⁿˢ::Vector{Transmission}`. In the case of a vector of transmission corridors, the
+  method returns the sum of the variable and fixed OPEX for all modes whose method of the
+  function [`has_opex`](@ref) returns true.
+- `𝒳 = 𝒜::Vector{<:Area}`. In the case of a vector of areas, the method returns a value of 0
+   for all investment periods.
+"""
+function EMB.objective_operational(
+    m,
+    ℒᵗʳᵃⁿˢ::Vector{Transmission},
+    𝒯ᴵⁿᵛ::TS.AbstractStratPers,
+    modeltype::EnergyModel,
+)
+    # Declaration of the required subsets
+    ℳ = modes(ℒᵗʳᵃⁿˢ)
+
+    return @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
+        sum((m[:trans_opex_var][tm, t_inv] + m[:trans_opex_fixed][tm, t_inv]) for tm ∈ ℳ)
+    )
+end
+function EMB.objective_operational(
+    m,
+    𝒜::Vector{<:Area},
+    𝒯ᴵⁿᵛ::TS.AbstractStratPers,
+    modeltype::EnergyModel,
+)
+    return @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ], 0)
 end
 
 """
     EMB.create_node(m, n::GeoAvailability, 𝒯, 𝒫, modeltype::EnergyModel)
 
-Set all constraints for a [`GeoAvailability`](@ref). The energy balance is handlded in the
-function [`constraints_area`](@ref). Hence, no constraints are added
+Set all constraints for a [`GeoAvailability`](@ref). The energy balance is handled in the
+function [`constraints_area`](@ref). Hence, no constraints are added in this function.
 """
 function EMB.create_node(m, n::GeoAvailability, 𝒯, 𝒫, modeltype::EnergyModel) end
 
@@ -282,61 +415,6 @@ function create_area(m, a::LimitedExchangeArea, 𝒯, ℒᵗʳᵃⁿˢ, modeltyp
     @constraint(m, [t ∈ 𝒯, p ∈ limit_resources(a)],
         m[:area_exchange][a, t, p] >= -1 * exchange_limit(a, p, t)) # Export limit
 
-end
-
-"""
-    constraints_transmission(m, 𝒯, ℳ, modeltype::EnergyModel)
-
-Create transmission constraints on all transmission corridors.
-"""
-function constraints_transmission(m, 𝒯, ℳ, modeltype::EnergyModel)
-
-    for tm ∈ ℳ
-        create_transmission_mode(m, tm, 𝒯, modeltype)
-    end
-end
-
-"""
-    update_objective(m, 𝒯, ℳ, modeltype::EnergyModel)
-
-Update the objective function with costs related to geography (areas and energy transmission).
-"""
-function update_objective(m, 𝒯, ℳ, modeltype::EnergyModel)
-
-    # Extraction of data
-    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    obj = objective_function(m)
-
-    # Calculate the OPEX cost contribution
-    opex = @expression(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
-        sum(m[:trans_opex_var][tm, t_inv] + m[:trans_opex_fixed][tm, t_inv] for tm ∈ ℳ)
-    )
-    # Update the objective
-    @objective(m, Max,
-        obj - sum(opex[t_inv] * duration_strat(t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ)
-    )
-end
-
-"""
-    update_total_emissions(m, 𝒯, ℳ, 𝒫, modeltype::EnergyModel)
-
-Update the constraints aggregating total emissions in each operational period with
-contributions from transmission emissions.
-"""
-function update_total_emissions(m, 𝒯, ℳ, 𝒫, modeltype::EnergyModel)
-    ℳᵉᵐ = filter(m -> has_emissions(m), ℳ)
-    𝒫ᵉᵐ  = EMB.res_sub(𝒫, EMB.ResourceEmit)
-
-    # Modify existing constraints on total emissions by adding contribution from
-    # transmission emissions. Note the coefficient is set to -1 since the total constraint
-    # has the variables on the RHS.
-    for tm ∈ ℳᵉᵐ, p ∈ 𝒫ᵉᵐ, t ∈ 𝒯
-        JuMP.set_normalized_coefficient(
-            m[:con_em_tot][t, p],
-            m[:emissions_trans][tm, t, p],
-            -1.0,
-        )
-    end
 end
 
 """

--- a/src/structures/area.jl
+++ b/src/structures/area.jl
@@ -1,5 +1,9 @@
-""" Declaration of the general type for areas."""
-abstract type Area end
+"""
+    Area <: AbstractElement
+
+Declaration of the general type for areas.
+"""
+abstract type Area <: AbstractElement end
 
 """
     RefArea <: Area

--- a/src/structures/case.jl
+++ b/src/structures/case.jl
@@ -1,0 +1,21 @@
+"""
+    get_areas(case::Case)
+    get_areas(𝒳::Vector{Vector})
+
+Returns the vector of areas of the Case `case` or the vector of elements vectors 𝒳.
+"""
+get_areas(case::Case) = filter(el -> isa(el, Vector{<:Area}), get_elements_vec(case))[1]
+get_areas(𝒳::Vector{Vector}) =
+    filter(el -> isa(el, Vector{<:Area}), 𝒳)[1]
+
+"""
+    get_transmissions(case::Case)
+    get_transmissions(𝒳::Vector{Vector})
+
+Returns the vector of transmission corridors of the Case `case` or the vector of elements
+vectors 𝒳.
+"""
+get_transmissions(case::Case) =
+    filter(el -> isa(el, Vector{<:Transmission}), get_elements_vec(case))[1]
+get_transmissions(𝒳::Vector{Vector}) =
+    filter(el -> isa(el, Vector{<:Transmission}), 𝒳)[1]

--- a/src/structures/transmission.jl
+++ b/src/structures/transmission.jl
@@ -1,13 +1,15 @@
-""" A `Transmission` corridor.
+"""
+    Transmission <: AbstractElement
 
-A geographic corridor where `TransmissionModes` are used to transport resources.
+A geographic corridor between two [`Area`](@ref)s where [`TransmissionMode`](@ref)s are used
+to transport resources.
 
 # Fields
 - **`from::Area`** is the area resources are transported from.
 - **`to::Area`** is the area resources are transported to.
 - **`modes::Vector{<:Transmission}`** are the transmission modes that are available.
 """
-struct Transmission
+struct Transmission <: AbstractElement
     from::Area
     to::Area
     modes::Vector{<:TransmissionMode}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,10 @@ include("utils.jl")
         include("test_checks.jl")
     end
 
+    @testset "Geography | Deprecation" begin
+        include("test_deprecation.jl")
+    end
+
     @testset "Geography | Investments" begin
         include("test_investments.jl")
     end

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -62,13 +62,12 @@ function simple_graph()
     )
 
 
-    # Creation of the case dictionary
-    case = Dict(:nodes => nodes,
-        :links => links,
-        :products => products,
-        :areas => areas,
-        :transmission => transmissions,
-        :T => T,
+    # Creation of the case type
+    case = Case(
+        T,
+        products,
+        [nodes, links, areas, transmissions],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
     )
     return case, modeltype, transmission_line
 end
@@ -80,27 +79,28 @@ end
 
         # Test that the Availability node is in the node vector
         case, model, trans_line = simple_graph()
-        case[:areas][1] = RefArea(1, "Factory", 10.751, 59.921, GeoAvailability("test", case[:products]))
-        case[:transmission][1] = Transmission(case[:areas][1], case[:areas][2], [trans_line])
-        @test_throws AssertionError EMG.create_model(case, model)
+        𝒫 = get_products(case)
+        case.elements[3][1] = RefArea(1, "Factory", 10.751, 59.921, GeoAvailability("test", 𝒫))
+        case.elements[4][1] = Transmission(case.elements[3][1], case.elements[3][2], [trans_line])
+        @test_throws AssertionError create_model(case, model)
 
         # Test that the availability node is a GeoAvailability node
         case, model, trans_line = simple_graph()
-        av = GenAvailability("test", case[:products])
-        case[:nodes][1] = av
-        case[:areas][1] = RefArea(1, "Factory", 10.751, 59.921, av)
-        case[:links][1] = Direct(31, case[:nodes][3], case[:nodes][1], Linear())
-        case[:transmission][1] = Transmission(case[:areas][1], case[:areas][2], [trans_line])
-        @test_throws AssertionError EMG.create_model(case, model)
+        av = GenAvailability("test", 𝒫)
+        case.elements[1][1] = av
+        case.elements[3][1] = RefArea(1, "Factory", 10.751, 59.921, av)
+        case.elements[2][1] = Direct(31, case.elements[1][3], case.elements[1][1], Linear())
+        case.elements[4][1] = Transmission(case.elements[3][1], case.elements[3][2], [trans_line])
+        @test_throws AssertionError create_model(case, model)
 
         # Test that the availability node includes as product the exchange resources
         case, model, trans_line = simple_graph()
-        av = GeoAvailability("test", Resource[case[:products][2]])
-        case[:nodes][1] = av
-        case[:areas][1] = RefArea(1, "Factory", 10.751, 59.921, av)
-        case[:links][1] = Direct(31, case[:nodes][3], case[:nodes][1], Linear())
-        case[:transmission][1] = Transmission(case[:areas][1], case[:areas][2], [trans_line])
-        @test_throws AssertionError EMG.create_model(case, model)
+        av = GeoAvailability("test", Resource[𝒫[2]])
+        case.elements[1][1] = av
+        case.elements[3][1] = RefArea(1, "Factory", 10.751, 59.921, av)
+        case.elements[2][1] = Direct(31, case.elements[1][3], case.elements[1][1], Linear())
+        case.elements[4][1] = Transmission(case.elements[3][1], case.elements[3][2], [trans_line])
+        @test_throws AssertionError create_model(case, model)
     end
 end
 
@@ -109,11 +109,11 @@ end
         # Test that the from and to fields are correctly checked
         # - check_elements(log_by_element, ℒᵗʳᵃⁿˢ::Vector{<:Tranmission}}, 𝒳, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
         case, model, trans_line = simple_graph()
-        area = RefArea(1, "TestArea", 10.751, 59.921, case[:nodes][1])
-        case[:transmission][1] = Transmission(case[:areas][1], area, [trans_line])
-        @test_throws AssertionError EMG.create_model(case, model)
-        case[:transmission][1] = Transmission(area, case[:areas][1], [trans_line])
-        @test_throws AssertionError EMG.create_model(case, model)
+        area = RefArea(1, "TestArea", 10.751, 59.921, case.elements[1][1])
+        case.elements[4][1] = Transmission(case.elements[3][1], area, [trans_line])
+        @test_throws AssertionError create_model(case, model)
+        case.elements[4][1] = Transmission(area, case.elements[3][1], [trans_line])
+        @test_throws AssertionError create_model(case, model)
     end
 end
 

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -1,94 +1,120 @@
 # Set the global to true to suppress the error message
 EMB.TEST_ENV = true
 
-@testset "Test checks - case dictionary" begin
-    # Resources used in the analysis
-    Power = ResourceCarrier("Power", 0.0)
-    CO2 = ResourceEmit("CO2", 1.0)
+# Resources used in the checks
+Power = ResourceCarrier("Power", 0.0)
+CO2 = ResourceEmit("CO2", 1.0)
+NG = ResourceEmit("NG", 0.2)
 
-    function small_graph()
-        products = [Power, CO2]
+# Function for setting up the system for testing Area checks
+function simple_graph()
+    products = [Power, CO2]
 
-        # Creation of the source and sink module as well as the arrays used for nodes and links
-        source = RefSource(
-            "src",
-            FixedProfile(25),
-            FixedProfile(10),
-            FixedProfile(5),
-            Dict(Power => 1),
-        )
-        sink = RefSink(
-            "sink",
-            FixedProfile(20),
-            Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
-            Dict(Power => 1),
-        )
+    # Creation of the source and sink module as well as the arrays used for nodes and links
+    source = RefSource(
+        "src",
+        FixedProfile(25),
+        FixedProfile(10),
+        FixedProfile(5),
+        Dict(Power => 1),
+    )
+    sink = RefSink(
+        "sink",
+        FixedProfile(20),
+        Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+        Dict(Power => 1),
+    )
 
-        nodes = [
-            GeoAvailability(1, products),
-            EMG.GeoAvailability(2, products),
-            source,
-            sink,
-        ]
-        links = [
-            Direct(31, nodes[3], nodes[1], Linear()),
-            Direct(24, nodes[2], nodes[4], Linear()),
-        ]
+    nodes = [
+        GeoAvailability(1, products),
+        GeoAvailability(2, products),
+        source,
+        sink,
+    ]
+    links = [
+        Direct(31, nodes[3], nodes[1], Linear()),
+        Direct(24, nodes[2], nodes[4], Linear()),
+    ]
 
-        # Creation of the two areas and potential transmission lines
-        areas = [
-            RefArea(1, "Factory", 10.751, 59.921, nodes[1]),
-            RefArea(2, "North Sea", 10.398, 63.4366, nodes[2]),
-        ]
+    # Creation of the two areas and potential transmission lines
+    areas = [
+        RefArea(1, "Factory", 10.751, 59.921, nodes[1]),
+        RefArea(2, "North Sea", 10.398, 63.4366, nodes[2]),
+    ]
 
-        transmission_line = RefStatic(
-            "Transline",
-            Power,
-            FixedProfile(30.0),
-            FixedProfile(0.05),
-            FixedProfile(0.05),
-            FixedProfile(0.05),
-            1,
-        )
-        transmissions = [Transmission(areas[1], areas[2], [transmission_line])]
+    transmission_line = RefStatic(
+        "Transline",
+        Power,
+        FixedProfile(30.0),
+        FixedProfile(0.05),
+        FixedProfile(0.05),
+        FixedProfile(0.05),
+        1,
+    )
+    transmissions = [Transmission(areas[1], areas[2], [transmission_line])]
 
-        # Creation of the time structure and the used global data
-        T = TwoLevel(4, 1, SimpleTimes(4, 1))
-        modeltype = OperationalModel(
-            Dict(CO2 => StrategicProfile([450, 400, 350, 300])),
-            Dict(CO2 => FixedProfile(0)),
-            CO2
-        )
+    # Creation of the time structure and the used global data
+    T = TwoLevel(4, 1, SimpleTimes(4, 1))
+    modeltype = OperationalModel(
+        Dict(CO2 => StrategicProfile([450, 400, 350, 300])),
+        Dict(CO2 => FixedProfile(0)),
+        CO2
+    )
 
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes,
-            :links => links,
-            :products => products,
-            :areas => areas,
-            :transmission => transmissions,
-            :T => T,
-        )
-        return case, modeltype
+    # Creation of the case dictionary
+    case = Dict(:nodes => nodes,
+        :links => links,
+        :products => products,
+        :areas => areas,
+        :transmission => transmissions,
+        :T => T,
+    )
+    return case, modeltype, transmission_line
+end
+
+@testset "Checks - Areas" begin
+    @testset "Core structure" begin
+        # Test that the availability node is correctly checked
+        # - check_elements(log_by_element, 𝒜::Vector{<:Area}}, 𝒳, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+
+        # Test that the Availability node is in the node vector
+        case, model, trans_line = simple_graph()
+        case[:areas][1] = RefArea(1, "Factory", 10.751, 59.921, GeoAvailability("test", case[:products]))
+        case[:transmission][1] = Transmission(case[:areas][1], case[:areas][2], [trans_line])
+        @test_throws AssertionError EMG.create_model(case, model)
+
+        # Test that the availability node is a GeoAvailability node
+        case, model, trans_line = simple_graph()
+        av = GenAvailability("test", case[:products])
+        case[:nodes][1] = av
+        case[:areas][1] = RefArea(1, "Factory", 10.751, 59.921, av)
+        case[:links][1] = Direct(31, case[:nodes][3], case[:nodes][1], Linear())
+        case[:transmission][1] = Transmission(case[:areas][1], case[:areas][2], [trans_line])
+        @test_throws AssertionError EMG.create_model(case, model)
+
+        # Test that the availability node includes as product the exchange resources
+        case, model, trans_line = simple_graph()
+        av = GeoAvailability("test", Resource[case[:products][2]])
+        case[:nodes][1] = av
+        case[:areas][1] = RefArea(1, "Factory", 10.751, 59.921, av)
+        case[:links][1] = Direct(31, case[:nodes][3], case[:nodes][1], Linear())
+        case[:transmission][1] = Transmission(case[:areas][1], case[:areas][2], [trans_line])
+        @test_throws AssertionError EMG.create_model(case, model)
     end
+end
 
-    # Check that the keys are present
-    # - EMG.check_case_data(case)
-    case, model = small_graph()
-    for key ∈ [:areas, :transmission]
-        case_test = deepcopy(case)
-        pop!(case_test, key)
-        @test_throws AssertionError EMG.create_model(case_test, model)
+@testset "Checks - Transmission" begin
+    @testset "Core structure" begin
+        # Test that the from and to fields are correctly checked
+        # - check_elements(log_by_element, ℒᵗʳᵃⁿˢ::Vector{<:Tranmission}}, 𝒳, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+        case, model, trans_line = simple_graph()
+        area = RefArea(1, "TestArea", 10.751, 59.921, case[:nodes][1])
+        case[:transmission][1] = Transmission(case[:areas][1], area, [trans_line])
+        @test_throws AssertionError EMG.create_model(case, model)
+        case[:transmission][1] = Transmission(area, case[:areas][1], [trans_line])
+        @test_throws AssertionError EMG.create_model(case, model)
     end
-
-    # Check that the keys are of the correct format and do not include any unwanted types
-    # - EMG.check_case_data(case)
-    case_test = deepcopy(case)
-    case_test[:areas] = [case[:areas], case[:areas], 10]
-    @test_throws AssertionError EMG.create_model(case_test, model)
-    case_test = deepcopy(case)
-    case_test[:transmission] = [case[:transmission], case[:transmission], 10]
-    @test_throws AssertionError EMG.create_model(case_test, model)
 end
 
 # Set the global again to false

--- a/test/test_deprecation.jl
+++ b/test/test_deprecation.jl
@@ -1,0 +1,93 @@
+
+@testset "create_model" begin
+    """
+        small_graph_dep()
+
+    Creates a simple geography test case for testing that the deprecation is working correctly.
+    """
+    function small_graph_dep()
+        # Declaration of the required resources
+        CO2 = ResourceEmit("CO2", 1.0)
+        Power = ResourceCarrier("Power", 0.0)
+        products = [Power, CO2]
+
+        # Creation of the source and sink module as well as the arrays used for nodes and links
+        source = RefSource(
+            "-src",
+            FixedProfile(50),
+            FixedProfile(10),
+            FixedProfile(5),
+            Dict(Power => 1),
+        )
+
+        sink = RefSink(
+            "-snk",
+            StrategicProfile([20, 25, 30, 35]),
+            Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+            Dict(Power => 1),
+        )
+
+        nodes = [GeoAvailability(1, products), GeoAvailability(2, products), source, sink]
+        links = [
+            Direct(31, nodes[3], nodes[1], Linear())
+            Direct(24, nodes[2], nodes[4], Linear())
+        ]
+
+        # Creation of the two areas and potential transmission lines
+        areas = [
+            RefArea(1, "Oslo", 10.751, 59.921, nodes[1]),
+            RefArea(2, "Trondheim", 10.398, 63.4366, nodes[2]),
+        ]
+
+        transmission_line = RefStatic(
+            "transline",
+            Power,
+            FixedProfile(40),
+            FixedProfile(0.1),
+            FixedProfile(0.0),
+            FixedProfile(0.0),
+            1,
+        )
+
+        transmissions = [Transmission(areas[1], areas[2], [transmission_line])]
+
+        # Creation of the time structure and the used global data
+        T = TwoLevel(4, 1, SimpleTimes(1, 1))
+        modeltype = OperationalModel(
+            Dict(CO2 => StrategicProfile([450, 400, 350, 300])),
+            Dict(CO2 => StrategicProfile([0, 0, 0, 0])),
+            CO2,
+        )
+
+        # Input data structures
+        case_old = Dict(
+            :nodes => nodes,
+            :links => links,
+            :products => products,
+            :areas => areas,
+            :transmission => transmissions,
+            :T => T,
+        )
+        case_new = Case(
+            T,
+            products,
+            [nodes, links, areas, transmissions],
+            [[get_nodes, get_links], [get_areas, get_transmissions]],
+        )
+        return case_new, case_old, modeltype
+    end
+    # Receive the case descriptions
+    case_new, case_old, modeltype = small_graph_dep()
+
+    # Create models based on both input and optimize it
+    m_new = optimize(case_new, modeltype)
+
+    m_old = EMG.create_model(case_old, modeltype)
+    set_optimizer(m_old, optimizer)
+    set_optimizer_attribute(m_old, MOI.Silent(), true)
+    optimize!(m_old)
+
+    # Test that the results are the same
+    @test objective_value(m_old) ≈ objective_value(m_new)
+    @test size(all_variables(m_old))[1] == size(all_variables(m_new))[1]
+end

--- a/test/test_geo.jl
+++ b/test/test_geo.jl
@@ -14,14 +14,14 @@ import EnergyModelsGeography; const EMG = EnergyModelsGeography
 m, case = EMG.run_model("", HiGHS.Optimizer)
 
 # Extract the indiviudal data from the model
-𝒯       = case[:T]
+𝒯       = get_time_struct(case)
 𝒯ᴵⁿᵛ    = strategic_periods(𝒯)
-𝒩       = case[:nodes]
+𝒩       = get_nodes(case)
 𝒩ⁿᵒᵗ    = EMB.node_not_av(𝒩)
 av      = 𝒩[findall(x -> isa(x, EMB.Availability), 𝒩)]
-𝒜       = case[:areas]
-ℒᵗʳᵃⁿˢ  = case[:transmission]
-𝒫       = case[:products]
+𝒜       = get_areas(case)
+ℒᵗʳᵃⁿˢ  = get_transmissions(case)
+𝒫       = get_products(case)
 
 CH4     = 𝒫[1]
 Power   = 𝒫[3]
@@ -103,7 +103,7 @@ function system_map()
 
     linestyle = attr(line= attr(width = 2.0, dash="dash"))
     lines = []
-    for l ∈ case[:transmission]
+    for l ∈ get_transmissions(case)
         line = scattergeo(;mode="lines", lat=[l.from.lat, l.to.lat], lon=[l.from.lon, l.to.lon],
                         marker=linestyle, width=2.0,  name=join([tm.id for cm ∈ modes(l)]))
         lines = vcat(lines, [line])
@@ -144,7 +144,7 @@ function resource_map_avg(m, resource, times, lines; line_scale = 10, node_scale
     mean_values = Dict(k=> round(Statistics.mean(v), digits=2) for (k, v) ∈ trans)
     scale = line_scale/maximum(values(mean_values))
     lines = []
-    for l ∈ case[:transmission]
+    for l ∈ get_transmissions(case)
         line = scattergeo(;lat=[l.from.lat, l.to.lat], lon=[l.from.lon, l.to.lon],
                           mode="lines", line = attr(width=mean_values[l]*scale),
                           text =  mean_values[l], name=join([tm.id for cm ∈ modes(l)]))

--- a/test/test_geo_bidirectional.jl
+++ b/test/test_geo_bidirectional.jl
@@ -1,5 +1,3 @@
-
-
 function bidirectional_case()
 
     # Definition of the individual resources used in the simple system
@@ -9,7 +7,7 @@ function bidirectional_case()
     products = [NG, Power, CO2]
 
     # Creation of the time structure and the used global data
-    𝒯 = TwoLevel(1, 1, SimpleTimes(2, 1); op_per_strat=2)
+    T = TwoLevel(1, 1, SimpleTimes(2, 1); op_per_strat=2)
     modeltype = OperationalModel(
                                 Dict(
                                     CO2 => FixedProfile(1e10),
@@ -69,15 +67,13 @@ function bidirectional_case()
     )
     transmission = [Transmission(areas[1], areas[2], [transmission_line])]
 
-    # Aggregation of the problem case
-    case = Dict(
-                :nodes          => Array{EMB.Node}(nodes),
-                :links          => Array{Link}(links),
-                :products       => products,
-                :areas          => Array{Area}(areas),
-                :transmission   => Array{Transmission}(transmission),
-                :T              => 𝒯,
-                )
+    # Input data structure
+    case = Case(
+        T,
+        products,
+        [nodes, links, areas, transmission],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
+    )
     return case, modeltype
 end
 
@@ -91,8 +87,8 @@ m = optimize(case, modeltype)
 general_tests(m)
 
 # Reassigning the case data
-𝒯   = case[:T]
-l   = case[:transmission][1]
+𝒯   = get_time_struct(case)
+l   = get_transmissions(case)[1]
 tm  = modes(l)[1]
 
 # The sign should be the same for both directions

--- a/test/test_geo_unidirectional.jl
+++ b/test/test_geo_unidirectional.jl
@@ -54,29 +54,26 @@ function small_graph(source=nothing, sink=nothing)
                                 CO2,
     )
 
-
-    # Creation of the case dictionary
-    case = Dict(:nodes          => nodes,
-                :links          => links,
-                :products       => products,
-                :areas          => areas,
-                :transmission   => transmissions,
-                :T              => T,
-                )
+    # Input data structure
+    case = Case(
+        T,
+        products,
+        [nodes, links, areas, transmissions],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
+    )
     return case, modeltype
 end
 
 function transmission_tests(m, case)
     # Extraction of relevant data from the model
-    source  = case[:nodes][3]
-    sink    = case[:nodes][4]
-    𝒯       = case[:T]
-    Power   = case[:products][1]
+    𝒩 = get_nodes(case)
+    source  = 𝒩[3]
+    sink    = 𝒩[4]
+    𝒯       = get_time_struct(case)
 
-    tr_osl_trd, tr_trd_osl  = case[:transmission]
+    tr_osl_trd, tr_trd_osl  = get_transmissions(case)
     tr_osl_trd_mode         = modes(tr_osl_trd)[1]
     tr_trd_osl_mode         = modes(tr_trd_osl)[1]
-    areas                   = case[:areas]
 
     @testset "Test transmission" begin
 
@@ -125,7 +122,7 @@ end
     case, modeltype = small_graph()
 
     # Replace each TransmissionMode's with a PipeSimple with identical properties.
-    for transmission in case[:transmission]
+    for transmission in get_transmissions(case)
         for (i, prev_tm) ∈ enumerate(modes(transmission))
             pipeline = PipeSimple(repr(prev_tm),
                                         inputs(prev_tm)[1],

--- a/test/test_investments.jl
+++ b/test/test_investments.jl
@@ -74,16 +74,13 @@ function small_graph_geo(; source = nothing, sink = nothing, inv_data = nothing)
         0.07,
     )
 
-    # Creation of the case dictionary
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :areas => areas,
-        :transmission => transmissions,
-        :T => T,
+    # Input data structure
+    case = Case(
+        T,
+        products,
+        [nodes, links, areas, transmissions],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
     )
-
     return case, modeltype
 end
 
@@ -98,10 +95,10 @@ end
     general_tests(m)
 
     # Extraction of required data
-    𝒯 = case[:T]
+    𝒯 = get_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    sink = case[:nodes][4]
-    tr_osl_trd = case[:transmission][1]
+    sink = get_nodes(case)[4]
+    tr_osl_trd = get_transmissions(case)[1]
     tm = modes(tr_osl_trd)[1]
 
     # Test identifying that the proper deficit is calculated
@@ -134,10 +131,10 @@ end
     general_tests(m)
 
     # Extraction of required data
-    𝒯 = case[:T]
+    𝒯 = get_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    sink = case[:nodes][4]
-    tr_osl_trd = case[:transmission][1]
+    sink = get_nodes(case)[4]
+    tr_osl_trd = get_transmissions(case)[1]
     tm = modes(tr_osl_trd)[1]
     inv_data = EMI.investment_data(tm, :cap)
 
@@ -186,10 +183,10 @@ end
     general_tests(m)
 
     # Extraction of required data
-    𝒯 = case[:T]
+    𝒯 = get_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    sink = case[:nodes][4]
-    tr_osl_trd = case[:transmission][1]
+    sink = get_nodes(case)[4]
+    tr_osl_trd = get_transmissions(case)[1]
     tm = modes(tr_osl_trd)[1]
     inv_data = EMI.investment_data(tm, :cap)
 
@@ -260,10 +257,10 @@ end
     general_tests(m)
 
     # Extraction of required data
-    𝒯 = case[:T]
+    𝒯 = get_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    sink = case[:nodes][4]
-    tr_osl_trd = case[:transmission][1]
+    sink = get_nodes(case)[4]
+    tr_osl_trd = get_transmissions(case)[1]
     tm = modes(tr_osl_trd)[1]
     inv_data = EMI.investment_data(tm, :cap)
     inv_mode = EMI.investment_mode(inv_data)
@@ -338,10 +335,10 @@ end
     general_tests(m)
 
     # Extraction of required data
-    𝒯 = case[:T]
+    𝒯 = get_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    sink = case[:nodes][4]
-    tr_osl_trd = case[:transmission][1]
+    sink = get_nodes(case)[4]
+    tr_osl_trd = get_transmissions(case)[1]
     tm = modes(tr_osl_trd)[1]
     inv_data = EMI.investment_data(tm, :cap)
 

--- a/test/test_simplelinepack.jl
+++ b/test/test_simplelinepack.jl
@@ -57,15 +57,14 @@ function small_graph_linepack()
                                 CO2
     )
 
-
-    # Creation of the case dictionary
-    case = Dict(:nodes => nodes,
-        :links => links,
-        :products => products,
-        :areas => areas,
-        :transmission => transmissions,
-        :T => T,
+    # Input data structure
+    case = Case(
+        T,
+        products,
+        [nodes, links, areas, transmissions],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
     )
+
     return case, modeltype
 end
 
@@ -79,19 +78,20 @@ TODO:
 - check that transport is above zero.
 - why doesnt it work if we remove the el_sink node?
 """
-𝒯 = case[:T]
-𝒫 = case[:products]
-𝒩 = case[:nodes]
-ℒ = case[:transmission]
+𝒯 = get_time_struct(case)
+𝒫 = get_products(case)
+𝒩 = get_nodes(case)
+ℒ = get_transmissions(case)
+𝒜 = get_areas(case)
 
 Power = 𝒫[1]
-area_from = case[:areas][1]
-area_to = case[:areas][2]
+area_from = 𝒜[1]
+area_to = 𝒜[2]
 
 source = 𝒩[3]
 sink = 𝒩[4]
 
-transmission = case[:transmission][1]
+transmission = ℒ[1]
 pipeline = modes(transmission)[1]
 
 # Defining the required sets

--- a/test/test_simplepipe.jl
+++ b/test/test_simplepipe.jl
@@ -55,15 +55,14 @@ function small_graph_co2_1()
                                 CO2
                                 )
 
-
-    # Creation of the case dictionary
-    case = Dict(:nodes => nodes,
-        :links => links,
-        :products => products,
-        :areas => areas,
-        :transmission => transmissions,
-        :T => T,
+    # Input data structure
+    case = Case(
+        T,
+        products,
+        [nodes, links, areas, transmissions],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
     )
+
     return case, modeltype
 end
 
@@ -72,17 +71,18 @@ case, modeltype = small_graph_co2_1()
 m = optimize(case, modeltype)
 general_tests(m)
 
-𝒯 = case[:T]
-𝒫 = case[:products]
-𝒩 = case[:nodes]
-ℒ = case[:transmission]
+𝒯 = get_time_struct(case)
+𝒫 = get_products(case)
+𝒩 = get_nodes(case)
+ℒ = get_transmissions(case)
+𝒜 = get_areas(case)
 
 Power = 𝒫[1]
 CO2_150 = 𝒫[3]
 CO2_200 = 𝒫[4]
 
-area_from = case[:areas][1]
-area_to = case[:areas][2]
+area_from = 𝒜[1]
+area_to = 𝒜[2]
 
 a1 = 𝒩[1]
 a2 = 𝒩[2]
@@ -90,7 +90,7 @@ source = 𝒩[3]
 sink = 𝒩[4]
 el_sink = 𝒩[5]
 
-transmission = case[:transmission][1]
+transmission = ℒ[1]
 pipeline = modes(transmission)[1]
 inlet_resource = pipeline.inlet
 outlet_resource = pipeline.outlet

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,9 +1,9 @@
 @testset "Filter nodes by area" begin
     # This test uses the data from `test_geo_bidirectional.jl.`
     case, m = bidirectional_case()
-    areas = case[:areas]
-    nodes = case[:nodes]
-    links = case[:links]
+    areas = get_areas(case)
+    nodes = get_nodes(case)
+    links = get_links(case)
 
     a1 = areas[1]
     a2 = areas[2]
@@ -24,9 +24,9 @@ end
 @testset "Filter nodes by area - new method" begin
     # Using the same test set as in the original method
     case, m = bidirectional_case()
-    areas = case[:areas]
-    nodes = case[:nodes]
-    links = case[:links]
+    areas = get_areas(case)
+    nodes = get_nodes(case)
+    links = get_links(case)
 
     a1 = areas[1]
     a2 = areas[2]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -5,7 +5,7 @@ const ROUND_DIGITS = 8
 using HiGHS
 
 function optimize(case, modeltype)
-    m = EMG.create_model(case, modeltype)
+    m = create_model(case, modeltype)
     optimizer = HiGHS.Optimizer
     set_optimizer(m, optimizer)
     set_optimizer_attribute(m, MOI.Silent(), true)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -3,10 +3,10 @@ const ROUND_DIGITS = 8
 ⪆(x, y) = x > y || isapprox(x, y; atol = TEST_ATOL)
 
 using HiGHS
+optimizer = HiGHS.Optimizer
 
 function optimize(case, modeltype)
     m = create_model(case, modeltype)
-    optimizer = HiGHS.Optimizer
     set_optimizer(m, optimizer)
     set_optimizer_attribute(m, MOI.Silent(), true)
     optimize!(m)


### PR DESCRIPTION
In *[`EnergyModelsBase` release 0.9.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0)*, we introduced a new `Case` type that can be used for subsequent extensions of the model. While version 0.10. of `EnergyModelsGeography` is directly working with the new EMB version, it is beneficial to adjust it to follow the new guidelines.

## Changes

- Declared all `AbstractArea` and `Transmission` as subtype of `AbstractElement`.
- Adjusted all functions within `EnergyModelsGeography` to follow the approach from `EnergyModelsBase`.
 
> [!NOTE]  
> I plan to have a few more smaller PRs before registering the new version.