### PR TITLE
Reworked checks on bidirectional modes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
   This method allows for an arbitrary connection of links between a node and the availability node.
 * Minor typo updates in the documentation.
 * Removed the function `modes_of_dir` and replaced its use with `filter(is_bidirectional, ℳ)`.
-  In the case of filtering for single modes, we can use `filter(!is_bidirectional, ℳ)`.
+  In the case of filtering for unidirectional modes, we can use `filter(!is_bidirectional, ℳ)`.
 
 ## Version 0.10.1 (2024-10-16)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 * Included a new method for identifying nodes within an area using breadth-first search.
   This method allows for an arbitrary connection of links between a node and the availability node.
 * Minor typo updates in the documentation.
+* Removed the function `modes_of_dir` and replaced its use with `filter(is_bidirectional, ℳ)`.
+  In the case of filtering for single modes, we can use `filter(!is_bidirectional, ℳ)`.
 
 ## Version 0.10.1 (2024-10-16)
 

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -9,7 +9,7 @@ We will as well implement information regarding the adjustment of extension pack
 
 Starting from version 0.11.0, we introduced a new input format to the function `create_model`.
 The original case dictionary is replaced with a new type, [`Case`](@extref EnergyModelsBase.Case).
-Backwards-compatible methods are available to use with the original dictionary, however these are deprecated and we advise to switch to the new type::
+Backwards-compatible methods are available to use with the original dictionary, however these are deprecated and we advise to switch to the new type:
 
 ```julia
 # Old structure:

--- a/docs/src/library/public/transmission.md
+++ b/docs/src/library/public/transmission.md
@@ -22,5 +22,4 @@ modes_sub
 corr_from
 corr_to
 corr_from_to
-modes_of_dir
 ```

--- a/src/EnergyModelsGeography.jl
+++ b/src/EnergyModelsGeography.jl
@@ -44,7 +44,7 @@ export getnodesinarea, nodes_in_area
 export name, availability_node, limit_resources, exchange_limit, exchange_resources
 
 # Export commonly used functions for exctracting fields in `Transmission`s
-export modes, mode_sub, modes_sub, corr_from, corr_to, corr_from_to, modes_of_dir
+export modes, mode_sub, modes_sub, corr_from, corr_to, corr_from_to
 
 # Export commonly used functions for extracting fields in `TransmissionMode`s
 export map_trans_resource

--- a/src/model.jl
+++ b/src/model.jl
@@ -215,7 +215,7 @@ These variables are:
 """
 function variables_trans_mode(m, 𝒯, ℳˢᵘᵇ::Vector{<:TransmissionMode}, modeltype::EnergyModel)
 
-    ℳ₂ = modes_of_dir(ℳˢᵘᵇ, 2)
+    ℳ₂ = filter(is_bidirectional, ℳˢᵘᵇ)
 
     @variable(m, trans_loss[ℳˢᵘᵇ, 𝒯] >= 0)
     @variable(m, trans_neg[ℳ₂, 𝒯] >= 0)

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -95,6 +95,9 @@ end
     abstract type PipeMode <: TransmissionMode
 
 `TransmissionMode` mode for additional variable potential.
+
+`PipeMode`s are by default unidirectional. If you plan to include bidirectional pipelines,
+you have to provide a new method to the function [`is_bidirectional`](@ref).
 """
 abstract type PipeMode <: TransmissionMode end
 
@@ -142,35 +145,7 @@ struct PipeSimple <: PipeMode
     trans_loss::TimeProfile
     opex_var::TimeProfile
     opex_fixed::TimeProfile
-    directions::Int
     data::Vector{<:Data}
-
-    function PipeSimple(
-        id::String,
-        inlet::EMB.Resource,
-        outlet::EMB.Resource,
-        consuming::EMB.Resource,
-        consumption_rate::TimeProfile,
-        trans_cap::TimeProfile,
-        trans_loss::TimeProfile,
-        opex_var::TimeProfile,
-        opex_fixed::TimeProfile,
-        data::Vector{<:Data}
-    )
-        new(
-            id,
-            inlet,
-            outlet,
-            consuming,
-            consumption_rate,
-            trans_cap,
-            trans_loss,
-            opex_var,
-            opex_fixed,
-            1,
-            data,
-            )
-    end
 end
 function PipeSimple(
     id::String,
@@ -230,37 +205,7 @@ struct PipeLinepackSimple <: PipeMode
     opex_var::TimeProfile
     opex_fixed::TimeProfile
     energy_share::Float64
-    directions::Int
     data::Vector{<:Data}
-
-    function PipeLinepackSimple(
-        id::String,
-        inlet::EMB.Resource,
-        outlet::EMB.Resource,
-        consuming::EMB.Resource,
-        consumption_rate::TimeProfile,
-        trans_cap::TimeProfile,
-        trans_loss::TimeProfile,
-        opex_var::TimeProfile,
-        opex_fixed::TimeProfile,
-        energy_share::Float64,
-        data::Vector{<:Data},
-    )
-        new(
-            id,
-            inlet,
-            outlet,
-            consuming,
-            consumption_rate,
-            trans_cap,
-            trans_loss,
-            opex_var,
-            opex_fixed,
-            energy_share,
-            1,
-            data,
-        )
-    end
 end
 function PipeLinepackSimple(
     id::String,
@@ -331,16 +276,6 @@ Returns the transported resource for a given TransmissionMode.
 """
 map_trans_resource(tm::TransmissionMode) = tm.resource
 map_trans_resource(tm::PipeMode) = tm.inlet
-
-"""
-    modes_of_dir(ℒ, dir::Int)
-
-Return the transmission modes of dir `directions` for transmission modes `ℳ`.
-"""
-function modes_of_dir(ℳ::Vector{<:TransmissionMode}, dir::Int)
-
-    return filter(x -> x.directions == dir, ℳ)
-end
 
 """
     capacity(tm::TransmissionMode)
@@ -452,10 +387,15 @@ energy_share(tm::PipeLinepackSimple) = tm.energy_share
 
 """
     is_bidirectional(tm::TransmissionMode)
+    is_bidirectional(tm::PipeMode)
 
-Checks whether transmission mode `tm` is bidirectional.
+Checks whether transmission mode `tm` is bidirectional. By default, it checks whether the
+the function [`directions`](@ref) returns the value 2.
+
+[`PipeMode`](@ref)s return false.
 """
-is_bidirectional(tm::TransmissionMode) = tm.directions == 2
+is_bidirectional(tm::TransmissionMode) = directions(tm) == 2
+is_bidirectional(tm::PipeMode) = false
 
 """
     mode_data(tm::TransmissionMode)

--- a/src/structures/transmission.jl
+++ b/src/structures/transmission.jl
@@ -57,12 +57,3 @@ end
 function modes_sub(ℒᵗʳᵃⁿˢ::Vector{<:Transmission}, p::Resource)
     return filter(tm -> map_trans_resource(tm) == p, modes(ℒᵗʳᵃⁿˢ))
 end
-
-"""
-    modes_of_dir(l, dir::Int)
-
-Return the transmission modes of dir `directions` for transmission corridor `l``.
-"""
-function modes_of_dir(l::Transmission, dir::Int)
-    return filter(x -> x.directions == dir, modes(l))
-end


### PR DESCRIPTION
So far, we had a function `modes_of_dir` to filter for bidirectional of unidirectional modes. This is replaced by explicitly filtering in the respective functions to improve the understandability. At the same time, I removed the internal constructor for the 2 `PipeMode` as it is not really necessary any longer.