### PR TITLE
Allow for modes without OPEX

### DIFF
--- a/docs/src/library/internals/methods_EMB.md
+++ b/docs/src/library/internals/methods_EMB.md
@@ -38,6 +38,12 @@ EMB.opex_fixed
 EMB.opex_var
 ```
 
+## [Identification methods](@id lib-int-met_emb-fun_identify)
+
+```@docs
+EMB.has_opex
+```
+
 ## [Check methods](@id lib-int-fun-check)
 
 ```@docs

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -340,6 +340,15 @@ Returns the directions of transmission mode `tm`.
 directions(tm::TransmissionMode) = tm.directions
 
 """
+    has_opex(tm::TransmissionMode)
+
+Checks whether transmission mode `tm` has operational expenses.
+
+By default, all transmission modes have operational expenses.
+"""
+EMB.has_opex(tm::TransmissionMode) = true
+
+"""
     has_emissions(tm::TransmissionMode)
 
 Returns whether there are emissions associated with transmission mode `tm`.

--- a/test/test_geo_opex.jl
+++ b/test/test_geo_opex.jl
@@ -1,92 +1,121 @@
-function solve_and_check(case, modeltype, A_B_t1, B_A_t2)
+@testset "Calculation of OPEX" begin
+    function solve_and_check(case, modeltype, A_B_t1, B_A_t2)
+
+        # Create and solve the model
+        m = optimize(case, modeltype)
+
+        # Get times and transmission mode
+        T = collect(get_time_struct(case))
+        tm = modes(get_transmissions(case))[1]
+
+
+        if typeof(A_B_t1) == String
+            A_B_t1 = getfield(tm, Symbol(A_B_t1))[T[1]]
+        end
+        if typeof(B_A_t2) == String
+            B_A_t2 = getfield(tm, Symbol(B_A_t2))[T[2]]
+        end
+
+        # Check flow in the positive direction in t1
+        @test value.(m[:trans_out])[tm, T[1]] == A_B_t1
+        # Check flow in the negative direction in t2
+        @test abs(value.(m[:trans_in])[tm, T[2]]) == B_A_t2
+
+        return m
+    end
+
+    # Reading of the case data
+    case, modeltype = bidirectional_case()
+
+    tm = modes(get_transmissions(case))[1]
+    Power = get_products(case)[2]
+
+    t_cap = FixedProfile(30.0)
+    t_loss = FixedProfile(0.0)
+    t_opex_var = FixedProfile(0.0)
+    t_opex_fixed = FixedProfile(0.0)
+
+    # increase opex var, but not enough to change the results
+    case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
 
     # Create and solve the model
     m = optimize(case, modeltype)
 
-    # Get times and transmission mode
-    T = collect(get_time_struct(case))
-    tm = modes(get_transmissions(case))[1]
+    # Get reference objective value without any trans opex
+    obj_val_no_opex = objective_value(m)
 
+    fuel_opex_diff = 90
+    gen_fuel_coeff = 2
+    marginal_diff = 1
 
-    if typeof(A_B_t1) == String
-        A_B_t1 = getfield(tm, Symbol(A_B_t1))[T[1]]
-    end
-    if typeof(B_A_t2) == String
-        B_A_t2 = getfield(tm, Symbol(B_A_t2))[T[2]]
-    end
+    # TEST 1: Low trans opex does not change results
 
-    # Check flow in the positive direction in t1
-    @test value.(m[:trans_out])[tm, T[1]] == A_B_t1
-    # Check flow in the negative direction in t2
-    @test abs(value.(m[:trans_in])[tm, T[2]]) == B_A_t2
+    # Cange transmission mode parameters
+    t_opex_var = FixedProfile((fuel_opex_diff - marginal_diff) * gen_fuel_coeff)
+    case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
 
-    return m
+    m = solve_and_check(case, modeltype, "trans_cap", "trans_cap")
+
+    # TEST 2: Opex restricts flow in both periods
+
+    # increase opex var, so high that transmission in not profitable
+    t_opex_var = FixedProfile((fuel_opex_diff + marginal_diff) * gen_fuel_coeff)
+    case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
+
+    m = solve_and_check(case, modeltype, 0.0, 0.0)
+
+    # TEST 3: fixed opex does not change flow, but does change the objective value
+
+    # Cange transmission mode parameters
+    t_opex_var = FixedProfile(0.0) # no opex var
+    t_opex_fixed = FixedProfile(1e3) # high opex fixed
+    case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
+
+    m = solve_and_check(case, modeltype, "trans_cap", "trans_cap")
+
+    # Check objective value
+    @test objective_value(m) == obj_val_no_opex - 1e3 * capacity(tm).val
+
+    # TEST 4: Repeat TEST 1 with unidirectional transmission mode
+
+    # Cange transmission mode parameters
+    t_opex_var = FixedProfile((fuel_opex_diff - marginal_diff) * gen_fuel_coeff)
+    case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 1)
+
+    m = solve_and_check(case, modeltype, "trans_cap", 0.0)
+
+    # TEST 5: Repeat TEST 2 with unidirectional transmission mode
+
+    # increase opex var, so high that transmission in not profitable
+    t_opex_var = FixedProfile((fuel_opex_diff + marginal_diff) * gen_fuel_coeff)
+    case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 1)
+
+    m = solve_and_check(case, modeltype, 0.0, 0.0)
 end
 
-# Reading of the case data
-case, modeltype = bidirectional_case()
+@testset "Modes without OPEX" begin
+    # Introduce a new NoOPEXMode type
+    struct NoOPEXMode <: TransmissionMode
+        id::String
+        resource::EMB.Resource
+        trans_cap::TimeProfile
+        trans_loss::TimeProfile
+    end
+    EMG.has_opex(tm::NoOPEXMode) = false
+    EMG.is_bidirectional(tm::NoOPEXMode) = false
 
-tm = modes(get_transmissions(case))[1]
-Power = get_products(case)[2]
+    # Definition of the individual resources used in the simple system
+    Power = ResourceCarrier("Power", 0.)
+    CO2 = ResourceEmit("CO2",1.)
+    products = [Power, CO2]
 
-t_cap = FixedProfile(30.0)
-t_loss = FixedProfile(0.0)
-t_opex_var = FixedProfile(0.0)
-t_opex_fixed = FixedProfile(0.0)
+    mode = NoOPEXMode(
+        "no_opex_mode", Power, FixedProfile(50), FixedProfile(0)
+    )
+    case, modeltype = simple_case_new_mode(mode, products)
+    m = create_model(case, modeltype)
 
-# increase opex var, but not enough to change the results
-case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
-
-# Create and solve the model
-m = optimize(case, modeltype)
-
-# Get reference objective value without any trans opex
-obj_val_no_opex = objective_value(m)
-
-fuel_opex_diff = 90
-gen_fuel_coeff = 2
-marginal_diff = 1
-
-# TEST 1: Low trans opex does not change results
-
-# Cange transmission mode parameters
-t_opex_var = FixedProfile((fuel_opex_diff - marginal_diff) * gen_fuel_coeff)
-case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
-
-m = solve_and_check(case, modeltype, "trans_cap", "trans_cap")
-
-# TEST 2: Opex restricts flow in both periods
-
-# increase opex var, so high that transmission in not profitable
-t_opex_var = FixedProfile((fuel_opex_diff + marginal_diff) * gen_fuel_coeff)
-case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
-
-m = solve_and_check(case, modeltype, 0.0, 0.0)
-
-# TEST 3: fixed opex does not change flow, but does change the objective value
-
-# Cange transmission mode parameters
-t_opex_var = FixedProfile(0.0) # no opex var
-t_opex_fixed = FixedProfile(1e3) # high opex fixed
-case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 2)
-
-m = solve_and_check(case, modeltype, "trans_cap", "trans_cap")
-
-# Check objective value
-@test objective_value(m) == obj_val_no_opex - 1e3 * capacity(tm).val
-
-# TEST 4: Repeat TEST 1 with unidirectional transmission mode
-
-# Cange transmission mode parameters
-t_opex_var = FixedProfile((fuel_opex_diff - marginal_diff) * gen_fuel_coeff)
-case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 1)
-
-m = solve_and_check(case, modeltype, "trans_cap", 0.0)
-
-# TEST 5: Repeat TEST 2 with unidirectional transmission mode
-
-# increase opex var, so high that transmission in not profitable
-t_opex_var = FixedProfile((fuel_opex_diff + marginal_diff) * gen_fuel_coeff)
-case.elements[4][1].modes[1] = RefStatic("Transline", Power, t_cap, t_loss, t_opex_var, t_opex_fixed, 1)
-
-m = solve_and_check(case, modeltype, 0.0, 0.0)
+    # Test that the OPEX variables are empty
+    @test isempty(m[:trans_opex_var])
+    @test isempty(m[:trans_opex_fixed])
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -23,3 +23,61 @@ function general_tests(m)
         end
     end
 end
+
+"""
+    simple_case_new_mode(mode, products)
+
+Test function for the transfer of a single resource using a `mode`. Te vector products must
+contain exactly 2 resources, one `ResourceEmit` and one `ResourceCarrier`.
+"""
+function simple_case_new_mode(mode, products)
+    # Extracting of the resources
+    Power = filter(!EMB.is_resource_emit, products)[1]
+    CO2 = filter(EMB.is_resource_emit, products)[1]
+
+    # Creation of the source and sink module as well as the arrays used for nodes and links
+    source = RefSource(
+        "-src",
+        FixedProfile(50),
+        FixedProfile(10),
+        FixedProfile(5),
+        Dict(Power => 1),
+    )
+
+    sink = RefSink(
+        "-snk",
+        StrategicProfile([20, 25, 30, 35]),
+        Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+        Dict(Power => 1),
+    )
+    nodes = [GeoAvailability(1, products), GeoAvailability(2, products), source, sink]
+    links = [
+        Direct(31, nodes[3], nodes[1], Linear())
+        Direct(24, nodes[2], nodes[4], Linear())
+    ]
+
+    # Creation of the two areas and potential transmission lines
+    areas = [
+        RefArea(1, "Oslo", 10.751, 59.921, nodes[1]),
+        RefArea(2, "Trondheim", 10.398, 63.4366, nodes[2]),
+    ]
+    transmissions = [Transmission(areas[1], areas[2], TransmissionMode[mode])]
+
+    # Creation of the time structure and the used global data
+    T = TwoLevel(4, 1, SimpleTimes(4, 2))
+    modeltype = OperationalModel(
+                                Dict(CO2 => FixedProfile(1e3)),
+                                Dict(CO2 => FixedProfile(0)),
+                                CO2
+                                )
+
+    # Input data structure
+    case = Case(
+        T,
+        products,
+        [nodes, links, areas, transmissions],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
+    )
+
+    return case, modeltype
+end


### PR DESCRIPTION
Similar to [PR 56 of `EMB`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/pull/56) for nodes, this PR introduces the potential for modes without OPEX,

The large change in additions and deletions is related to the setting the original OPEX tests within an own `testset` to differentiate between the different types of tests within the file.