### PR TITLE
Minor rework of emissions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,9 @@
 * Minor typo updates in the documentation.
 * Removed the function `modes_of_dir` and replaced its use with `filter(is_bidirectional, ℳ)`.
   In the case of filtering for unidirectional modes, we can use `filter(!is_bidirectional, ℳ)`.
+* Reworked emissions to dispatch on the function `has_emissions` from `EnergyModelsBase`:
+  * Added tests that the approach is working.
+  * Unify the approach to return a `TimeProfile` when no timeperiod is provided.
 
 ## Version 0.10.1 (2024-10-16)
 

--- a/docs/src/library/internals/functions.md
+++ b/docs/src/library/internals/functions.md
@@ -58,9 +58,8 @@ check_mode_default
 extract_resources
 export_resources
 import_resources
-has_emissions
-emission
 emit_resources
+emissions
 is_bidirectional
 trans_sub
 ```

--- a/docs/src/library/internals/methods_EMB.md
+++ b/docs/src/library/internals/methods_EMB.md
@@ -42,6 +42,7 @@ EMB.opex_var
 
 ```@docs
 EMB.has_opex
+EMB.has_emissions
 ```
 
 ## [Check methods](@id lib-int-fun-check)

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -244,12 +244,12 @@ function constraints_emission(m, tm::TransmissionMode, 𝒯, modeltype::EnergyMo
     if is_bidirectional(tm)
         @constraint(m, [t ∈ 𝒯, p_em ∈ emit_resources(tm)],
             m[:emissions_trans][tm, t, p_em] ==
-                emission(tm, p_em, t) * (m[:trans_pos][tm, t] + m[:trans_neg][tm, t])
+                emissions(tm, p_em, t) * (m[:trans_pos][tm, t] + m[:trans_neg][tm, t])
         )
     else
         @constraint(m, [t ∈ 𝒯, p_em ∈ emit_resources(tm)],
             m[:emissions_trans][tm, t, p_em] ==
-                emission(tm, p_em, t) * m[:trans_out][tm, t]
+                emissions(tm, p_em, t) * m[:trans_out][tm, t]
         )
     end
 end

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -352,31 +352,31 @@ EMB.has_opex(tm::TransmissionMode) = true
     has_emissions(tm::TransmissionMode)
 
 Returns whether there are emissions associated with transmission mode `tm`.
-Default behaviour is no emissions.
+The default behaviour is no emissions.
 """
-has_emissions(tm::TransmissionMode) = false
+EMB.has_emissions(tm::TransmissionMode) = false
 
 """
     emit_resources(m::TransmissionMode)
 
 Returns the types of emissions associated with transmission mode `tm`.
 """
-emit_resources(tm::TransmissionMode) = EMB.ResourceEmit[]
+emit_resources(tm::TransmissionMode) = ResourceEmit[]
 
 """
-    emission(tm::TransmissionMode, p::EMB.ResourceEmit)
-    emission(tm::TransmissionMode, p::EMB.ResourceEmit, t)
+    emissions(tm::TransmissionMode, p::ResourceEmit)
+    emissions(tm::TransmissionMode, p::ResourceEmit, t)
 
 Returns the emission of transmission mode `tm` of a specific resource `p` as `TimeProfile`
-or in operational period `ts`.
+or in operational period `t`.
 
 !!! note "Transmission emissions"
     None of the provided `TransmissionMode`s include emissions. If you plan to include
     emissions, you have to both create a new `TransmissionMode` and dispatch on this
     function.
 """
-emission(tm::TransmissionMode, p::EMB.ResourceEmit) = 0
-emission(tm::TransmissionMode, p::EMB.ResourceEmit, t) = 0
+emissions(tm::TransmissionMode, p::EMB.ResourceEmit) = FixedProfile(0)
+emissions(tm::TransmissionMode, p::EMB.ResourceEmit, t) = 0
 
 """
     consumption_rate(tm::PipeMode)

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -375,8 +375,8 @@ or in operational period `t`.
     emissions, you have to both create a new `TransmissionMode` and dispatch on this
     function.
 """
-emissions(tm::TransmissionMode, p::EMB.ResourceEmit) = FixedProfile(0)
-emissions(tm::TransmissionMode, p::EMB.ResourceEmit, t) = 0
+emissions(tm::TransmissionMode, p::ResourceEmit) = FixedProfile(0)
+emissions(tm::TransmissionMode, p::ResourceEmit, t) = 0
 
 """
     consumption_rate(tm::PipeMode)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,10 @@ include("utils.jl")
         include("test_simplelinepack.jl")
     end
 
+    @testset "Geography | Emissions" begin
+        include("test_emissions.jl")
+    end
+
     @testset "Geography | Utilities" begin
         include("test_utils.jl")
     end

--- a/test/test_emissions.jl
+++ b/test/test_emissions.jl
@@ -1,0 +1,178 @@
+# Declaration of a simple `EmissionMode`
+struct EmissionMode <: TransmissionMode
+    id::String
+    resource::EMB.Resource
+    trans_cap::TimeProfile
+    trans_loss::TimeProfile
+    opex_var::TimeProfile
+    opex_fixed::TimeProfile
+    emissions::Dict{<:ResourceEmit, <:TimeProfile}
+    directions::Int
+    data::Vector{Data}
+end
+EMB.has_emissions(tm::EmissionMode) = true
+EMG.emit_resources(tm::EmissionMode) = keys(tm.emissions)
+EMG.emissions(tm::EmissionMode, p_em::ResourceEmit, t) = tm.emissions[p_em][t]
+
+"""
+    simple_case_emissions(;directions=1, opex_a=FixedProfile(10), opex_b=FixedProfile(50))
+
+Simple test case for testing the functionality of emissions.
+"""
+function simple_case_emissions(
+    ;directions=1,
+    opex_a=FixedProfile(10),
+    opex_b=FixedProfile(50),
+)
+    # Creation of the individual resources
+    Power = ResourceCarrier("Power", 0.0)
+    CO2 = ResourceEmit("CO2", 1.0)
+    NG = ResourceEmit("NG", 1.0)
+    products = [Power, CO2, NG]
+
+    # Creation of the source and sink module as well as the arrays used for nodes and links
+    src_a = RefSource(
+        "src_a",
+        FixedProfile(100),
+        opex_a,
+        FixedProfile(0),
+        Dict(Power => 1),
+    )
+    snk_a = RefSink(
+        "snk_a",
+        OperationalProfile([20, 25, 30, 35]),
+        Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+        Dict(Power => 1),
+    )
+    src_b = RefSource(
+        "src_b",
+        FixedProfile(100),
+        opex_b,
+        FixedProfile(0),
+        Dict(Power => 1),
+    )
+    snk_b = RefSink(
+        "snk_b",
+        OperationalProfile([20, 25, 30, 35]),
+        Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+        Dict(Power => 1),
+    )
+    nodes = [
+        GeoAvailability(1, products), src_a, snk_a,
+        GeoAvailability(2, products), src_b, snk_b,
+    ]
+    links = [
+        Direct(31, nodes[1], nodes[3], Linear()),
+        Direct(31, nodes[2], nodes[1], Linear()),
+        Direct(24, nodes[4], nodes[6], Linear()),
+        Direct(24, nodes[5], nodes[4], Linear()),
+    ]
+
+    # Creation of the two areas and potential transmission lines
+    areas = [
+        RefArea(1, "area_a", 10.751, 59.921, nodes[1]),
+        RefArea(2, "area_b", 10.398, 63.4366, nodes[4]),
+    ]
+
+    em_mode = EmissionMode(
+        "emission_mode",
+        Power,
+        FixedProfile(40),
+        FixedProfile(0),
+        FixedProfile(0),
+        FixedProfile(0),
+        Dict(CO2 => FixedProfile(.5)),
+        directions,
+        Data[],
+    )
+
+    transmissions = [Transmission(areas[1], areas[2], [em_mode])]
+
+    # Creation of the time structure and the used global data
+    T = TwoLevel(4, 1, SimpleTimes(4, 2), op_per_strat=8.0)
+    modeltype = OperationalModel(
+        Dict(
+            CO2 => StrategicProfile([125, 100, 75, 50]),
+            NG => FixedProfile(0)
+        ),
+        Dict(CO2 => FixedProfile(0)),
+        CO2
+    )
+
+    # Input data structure and optimization model design
+    case = Case(
+        T,
+        products,
+        [nodes, links, areas, transmissions],
+        [[get_nodes, get_links], [get_areas, get_transmissions]],
+    )
+    return case, modeltype
+end
+
+@testset "Emission variable generation" begin
+    case, modeltype = simple_case_emissions()
+    m = create_model(case, modeltype)
+    em_mode = modes(get_transmissions(case)[1])[1]
+    CO2, NG = get_products(case)[[2,3]]
+    𝒯 = get_time_struct(case)
+
+    # Test that the variable for NG is fixed to 0 and the one for CO2 not
+    @test all(is_fixed(m[:emissions_trans][em_mode, t, NG]) for t ∈ 𝒯)
+    @test !any(is_fixed(m[:emissions_trans][em_mode, t, CO2]) for t ∈ 𝒯)
+end
+
+@testset "Unidirectional transport" begin
+    case, modeltype = simple_case_emissions()
+    m = optimize(case, modeltype)
+    em_mode = modes(get_transmissions(case)[1])[1]
+    CO2, NG = get_products(case)[[2,3]]
+    𝒯 = get_time_struct(case)
+
+    # Test that the emissions are correctly calculated, both based on the model and based on
+    # the knowledge of the value
+    # - constraints_emission(m, tm::TransmissionMode, 𝒯, modeltype::EnergyModel)
+    @test all(
+        value.(m[:emissions_trans][em_mode, t, CO2]) ≈
+            value(m[:trans_out][em_mode, t]) * 0.5
+    for t ∈ 𝒯)
+    opers = collect(𝒯)[1:4]
+    emit = OperationalProfile([20, 25, 30, 35])*.5  # Given through the transported capacity
+    @test all(
+        value.((m[:emissions_trans][em_mode, t, CO2])) ≈ emit[t]
+    for t ∈ opers)
+
+    # Test that the emissions are correctly included
+    @test all(
+        value.((m[:emissions_trans][em_mode, t, CO2])) ==
+            value(m[:emissions_total][t, CO2])
+    for t ∈ 𝒯)
+end
+
+@testset "Bidirectional transport" begin
+    opex_a = OperationalProfile([10, 100, 10, 100])
+    opex_b = OperationalProfile([100, 10, 100, 10])
+    case, modeltype = simple_case_emissions(;directions=2, opex_a, opex_b)
+    m = optimize(case, modeltype)
+    em_mode = modes(get_transmissions(case)[1])[1]
+    CO2, NG = get_products(case)[[2,3]]
+    𝒯 = get_time_struct(case)
+
+    # Test that the emissions are correctly calculated, both based on the model and based on
+    # the knowledge of the value
+    # - constraints_emission(m, tm::TransmissionMode, 𝒯, modeltype::EnergyModel)
+    @test all(
+        value.((m[:emissions_trans][em_mode, t, CO2])) ≈
+            (value(m[:trans_pos][em_mode, t]) + value(m[:trans_neg][em_mode, t])) * 0.5
+    for t ∈ 𝒯)
+    opers = collect(𝒯)[1:4]
+    emit = OperationalProfile([20, 25, 30, 35])*.5  # Given through the transported capacity
+    @test all(
+        value.((m[:emissions_trans][em_mode, t, CO2])) ≈ emit[t]
+    for t ∈ opers)
+
+    # Test that the emissions are correctly included
+    @test all(
+        value.((m[:emissions_trans][em_mode, t, CO2])) ==
+            value(m[:emissions_total][t, CO2])
+    for t ∈ 𝒯)
+end


### PR DESCRIPTION
So far, the individual inclusion of emissions for `TransmissionMode` was 1. not tested and 2. not entirely consistent with `EnergyModelsBase` due to creating also a function `has_emissions` locally. This is changed in this PR. 

This PR closes #9 for good.