### PR TITLE
Fixed a bug in coupling constraints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Version 0.11.1 (2025-04-24)
 
-* Fixed a bug that occured when the couplings were provided in the wrong way.
+* Fixed a bug that occured when the couplings were provided in the opposite way.
 
 ## Version 0.11.0 (2025-02-20)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Version 0.11.1 (2025-04-24)
+
+* Fixed a bug that occured when the couplings were provided in the wrong way.
+
 ## Version 0.11.0 (2025-02-20)
 
 ### Adjustments to EMB v0.9

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 0.11.1 (2025-04-24)
+## Version 0.11.1 (2025-06-02)
 
 * Fixed a bug that occured when the couplings were provided in the opposite way.
 
@@ -167,12 +167,12 @@ These changes are mainly:
 
 ### Change of indexing
 
-* Variables are now indexed _*via*_ the `TransmissionMode` and the time period instead of the using a `SparseAxisArray` and indexing _*via*_ `Transmission`, time period, and `TransmissionMode`. This also improves model generation time.
-* This adjustment requires the declaration of a new instance for each usage of a `TransmissionMode`, see, _e.g._, the changes in `scr\user_interface.jl`.
+* Variables are now indexed **via** the `TransmissionMode` and the time period instead of the using a `SparseAxisArray` and indexing **via** `Transmission`, time period, and `TransmissionMode`. This also improves model generation time.
+* This adjustment requires the declaration of a new instance for each usage of a `TransmissionMode`, see, *e.g.*, the changes in `scr\user_interface.jl`.
 
 ### Additional changes
 
-* Change of variable generation for individual transmission modes: Variable generation _*via*_ the function `variables_trans_mode(s)` is adjusted to follow the concept introduced in `EnergyModelsBase`.
+* Change of variable generation for individual transmission modes: Variable generation **via** the function `variables_trans_mode(s)` is adjusted to follow the concept introduced in `EnergyModelsBase`.
 * Move of the field `Data` from `Transmission` to `TransmissionMode`. This is required for the later application of dispatching in `EnergyModelsInvestments`.
 
 ## Version 0.3.1 (2023-02-16)
@@ -180,7 +180,7 @@ These changes are mainly:
 ### Introduction of linepacking
 
 * Redefinition of `PipelineMode` as abstract type `PipeMode` and introduction of `PipeSimple` as a composite type corresponding to the previous `PipelineMode`.
-* Introduction of a simple linepacking implementation _*via*_ the type `PipeLinepackSimple.
+* Introduction of a simple linepacking implementation **via** the type `PipeLinepackSimple.
 * Change of `Area` to `abstract type` to be able to dispatch on areas.
 * Rewriting how functions for variable generation are called for easier introduction of variables for different `TransmissionMode`s.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsGeography"
 uuid = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 authors = ["Espen Flo Bødal <Espen.Bodal@sintef.no>"]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/src/model.jl
+++ b/src/model.jl
@@ -315,7 +315,7 @@ function EMB.constraints_couple(m, 𝒜::Vector{<:Area}, ℒᵗʳᵃⁿˢ::Vecto
     end
 end
 function EMB.constraints_couple(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒜::Vector{<:Area}, 𝒫, 𝒯, modeltype::EnergyModel)
-    return constraints_couple(m, 𝒜, ℒᵗʳᵃⁿˢ, 𝒫, 𝒯, modeltype)
+    return EMB.constraints_couple(m, 𝒜, ℒᵗʳᵃⁿˢ, 𝒫, 𝒯, modeltype)
 end
 
 """

--- a/src/structures/area.jl
+++ b/src/structures/area.jl
@@ -56,8 +56,9 @@ end
     GeoAvailability <: EMB.Availability
 
 A geography `Availability` node for substituion of the general
-[`GenAvailability`](@extref EnergyModelsBase.GenAvailability) node. A `GeoAvailability` is required if
-transmission should be included between individual [`Area`](@refs due to a changed mass balance.
+[`GenAvailability`](@extref EnergyModelsBase.GenAvailability) node. A `GeoAvailability` is
+required if transmission should be included between individual [`Area`](@ref)s due to a
+changed mass balance.
 
 # Fields
 - **`id`** is the name/identifier of the node.

--- a/test/test_mode.jl
+++ b/test/test_mode.jl
@@ -567,6 +567,28 @@ end
         )
         bi_analysis(mode)
     end
+
+    @testset "Reversed couplings" begin
+        # Test that reversed couplings are working for EMG
+        tm = RefStatic(
+            "mode",
+            Power,
+            FixedProfile(20),
+            FixedProfile(0.01),
+            FixedProfile(0.1),
+            FixedProfile(2),
+            2,
+        )
+        case, modeltype = simple_geo_uni(tm)
+        case_rev = Case(
+            get_time_struct(case),
+            get_products(case),
+            get_elements_vec(case),
+            [[get_nodes, get_links], [get_transmissions, get_areas]],
+        )
+        m = optimize(case_rev, modeltype)
+        general_tests(m)
+    end
 end
 
 # Testset for PipeSimple


### PR DESCRIPTION
The coupling constraints required that the functions were added in the correct order. This is adjusted now in this PR, including a test for the identification of future problems.

As it is a bug, I will register it directly after acceptance.