### PR TITLE
Extended functionality of `nodes_in_area`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Version 0.11.2 (2025-06-15)
+
+* Changed the links returned from `nodes_in_area` to include all links within a given area.
+
 ## Version 0.11.1 (2025-06-02)
 
 * Fixed a bug that occured when the couplings were provided in the opposite way.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsGeography"
 uuid = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 authors = ["Espen Flo Bødal <Espen.Bodal@sintef.no>"]
-version = "0.11.1"
+version = "0.11.2"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -103,6 +103,8 @@ function connected_nodes(n::EMB.Node, ℒ::Vector{<:Link}, nodes::Vector{<:EMB.N
         elseif n_to == n && !(n_from ∈ nodes)
             push!(con_nodes, n_from)
             push!(con_links, l)
+        elseif (n_to == n || n_from == n)
+            push!(con_links, l)
         end
     end
     return unique(con_nodes), con_links

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -104,7 +104,9 @@ end
 
     # Test that the correct nodes are extracted
     @test all(n.id[1:3] == "a_" * string(k) for (k, _) ∈ enumerate(a) for n ∈ nodes[k])
+    @test all(n.id[1:3] ≠ "a_" * string(k) for (k, _) ∈ enumerate(a) for n ∈ setdiff(𝒩, nodes[k]))
 
     # Test that the correct links are extracted
     @test all(l.id[1:3] == "a_" * string(k) for (k, _) ∈ enumerate(a) for l ∈ links[k])
+    @test all(l.id[1:3] ≠ "a_" * string(k) for (k, _) ∈ enumerate(a) for l ∈ setdiff(ℒ, links[k]))
 end


### PR DESCRIPTION
Previously, not all links within an `Area` were returned by the function `nodes_in_area`. This is now changed and also tested.

I guess the approach with having `unique` at the top level is a bit lazy, but I considered to to be reasonable as the alternative would be to include as well a single `if` check in addition to see whether they are already included. I honestly do not think that this is faster.