### PR TITLE
Adjustment to EMB v0.9.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Unversioned
+
+* Use the new concepts for data variables introduced in [`EnergyModelsBase` v0.9.1](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.1).
+
 ## Version 0.11.2 (2025-06-15)
 
 * Changed the links returned from `nodes_in_area` to include all links within a given area.
@@ -139,12 +143,12 @@ These changes are mainly:
 
 ## Version 0.6.0 (2023-05-30)
 
-* Changed the structure in which the extra field `Data` is included in the nodes.
-* It is changed from `Dict{String, Data}` to `Array{data}`.
+* Changed the structure in which the extra field `Data` is included in the modes and nodes of the test set.
+* It is changed from `Dict{String, Data}` to `Array{Data}`.
 
 ## Version 0.5.2 (2023-05-16)
 
-* Bugfix in the example which lead to a tri*via*l solution in which no energy has to be converted.
+* Bugfix in the example which lead to a trivial solution in which no energy has to be converted.
 
 ## Version 0.5.1 (2023-04-30)
 

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 EMIExt = "EnergyModelsInvestments"
 
 [compat]
-EnergyModelsBase = "0.9.0"
+EnergyModelsBase = "0.9.1"
 EnergyModelsInvestments = "0.8"
 SparseVariables = "0.7.3"
 JuMP = "1.5"

--- a/docs/src/area_mode/mode.md
+++ b/docs/src/area_mode/mode.md
@@ -65,7 +65,7 @@ The fields of the types are given as:
   The fixed operating expenses are relative to the installed capacity (through the field `trans_cap`) and the chosen duration of a strategic period as outlined on *[Utilize `TimeStruct`](@extref EnergyModelsBase how_to-utilize_TS)*.\
   It is important to note that you can only use `FixedProfile` or `StrategicProfile` for the fixed OPEX, but not `RepresentativeProfile` or `OperationalProfile`.
   In addition, all values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is only used for providing additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
   !!! note

--- a/docs/src/library/internals/methods_EMB.md
+++ b/docs/src/library/internals/methods_EMB.md
@@ -25,6 +25,8 @@ EMB.variables_opex
 EMB.variables_capex(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳, 𝒯, modeltype::EnergyModel)
 EMB.variables_elements
 EMB.variables_element
+EMB.variables_element_ext_data
+EMB.variables_ext_data(m, _::Type{<:ExtensionData}, ℳ::Vector{<:TransmissionMode}, 𝒯, 𝒫, modeltype::EnergyModel)
 EMB.variables_emission
 ```
 

--- a/docs/src/library/internals/methods_EMIExt.md
+++ b/docs/src/library/internals/methods_EMIExt.md
@@ -25,6 +25,7 @@ EMG.constraints_capacity_installed(m, tm::TransmissionMode, 𝒯::TimeStructure,
 
 ```@docs
 EMB.objective_invest
+EMB.variables_ext_data(m, _::Type{SingleInvData}, ℳᴵⁿᵛ::Vector{<:TransmissionMode}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
 ```
 
 ## [EnergyModelsInvestments](@id lib-int-EMIext-EMI)

--- a/examples/investments.jl
+++ b/examples/investments.jl
@@ -150,7 +150,6 @@ function generate_example_data_geo()
         FixedProfile(0),
         FixedProfile(0),
         2,
-        [],
     )
 
     transmissions = [

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -238,7 +238,6 @@ function get_sub_system_data(
                 # Line above: This implies that storing CO2 requires Power
                 Dict(CO2 => 1),             # Output from the node with output ratio
                 # In practice, for CO₂ storage, this is never used.
-                Data[]
             ),
             RefSink(
                 j+7,                        # Node id

--- a/ext/EMIExt/model.jl
+++ b/ext/EMIExt/model.jl
@@ -30,9 +30,9 @@ function EMB.objective_invest(
 end
 
 """
-    EMB.variables_capex(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
+    EMB.variables_ext_data(m, _::Type{SingleInvData}, ℳᴵⁿᵛ::Vector{<:TransmissionMode}, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)
 
-Create variables for the capital costs for the investments in transmission.
+Create variables for the capital costs for the investments in transmission modes.
 
 Additional variables for investment in capacity:
 * `:trans_cap_capex` - CAPEX costs for increases in the capacity of a transmission mode
@@ -42,10 +42,15 @@ Additional variables for investment in capacity:
 * `:trans_cap_invest_b` - binary variable whether investments in capacity are happening
 * `:trans_cap_remove_b` - binary variable whether investments in capacity are removed
 """
-function EMB.variables_capex(m, ℒᵗʳᵃⁿˢ::Vector{Transmission}, 𝒳, 𝒯, modeltype::AbstractInvestmentModel)
+function EMB.variables_ext_data(
+    m,
+    _::Type{SingleInvData},
+    ℳᴵⁿᵛ::Vector{<:TransmissionMode},
+    𝒯,
+    𝒫,
+    modeltype::AbstractInvestmentModel
+)
     # Declaration of the required subsets
-    ℳ = modes(ℒᵗʳᵃⁿˢ)
-    ℳᴵⁿᵛ = filter(has_investment, ℳ)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Add transmission specific investment variables for each strategic period:

--- a/src/legacy_constructors.jl
+++ b/src/legacy_constructors.jl
@@ -27,7 +27,7 @@ end
         opex_var::TimeProfile,
         opex_fixed::TimeProfile,
         directions::Int = 1
-        data::Vector{Data} = Data[]
+        data::Vector{ExtensionData} = ExtensionData[]
     )
 
 Legacy constructor for a `PipeSimple`.
@@ -48,7 +48,7 @@ function PipeSimple(
     opex_var::TimeProfile,
     opex_fixed::TimeProfile,
     directions::Int,
-    data::Vector{Data},
+    data::Vector{ExtensionData},
 )
     @warn(
         "The used implementation of a `PipeSimple` will be discontinued in the near future. " *
@@ -84,7 +84,7 @@ function PipeSimple(;
     opex_var::TimeProfile,
     opex_fixed::TimeProfile,
     directions::Int = 1,
-    data::Vector{Data} = Data[],
+    data::Vector{ExtensionData} = ExtensionData[],
 )
     @warn(
         "The used implementation of a `PipeSimple` will be discontinued in the near future. " *
@@ -123,7 +123,7 @@ end
         opex_fixed::TimeProfile,
         energy_share::Float64,
         directions::Int = 1
-        data::Vector{Data} = Data[]
+        data::Vector{ExtensionData} = ExtensionData[]
     )
 
 Legacy constructor for a `PipeLinepackSimple`.
@@ -145,7 +145,7 @@ function PipeLinepackSimple(
     opex_fixed::TimeProfile,
     energy_share::Float64,
     directions::Int,
-    data::Vector{Data},
+    data::Vector{ExtensionData},
 )
     @warn(
         "The used implementation of a `PipeLinepackSimple` will be discontinued in the near future. " *
@@ -183,7 +183,7 @@ function PipeLinepackSimple(;
     opex_fixed::TimeProfile,
     energy_share::Float64,
     directions::Int = 1,
-    data::Vector{Data} = Data[],
+    data::Vector{ExtensionData} = ExtensionData[],
 )
     @warn(
         "The used implementation of a `PipeLinepackSimple` will be discontinued in the near future. " *

--- a/src/structures/mode.jl
+++ b/src/structures/mode.jl
@@ -23,8 +23,8 @@ Generic representation of dynamic transmission modes, using for example truck, s
 - **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.
 - **`directions`** is the number of directions the resource can be transported,
   1 is unidirectional (A->B) or 2 is bidirectional (A<->B).
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments). The field `data`
-  is conditional through usage of a constructor.
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
+  The field `data` is conditional through usage of a constructor.
 """
 struct RefDynamic <: TransmissionMode # *e.g.*, Trucks, ships etc.
     id::String
@@ -34,7 +34,7 @@ struct RefDynamic <: TransmissionMode # *e.g.*, Trucks, ships etc.
     opex_var::TimeProfile
     opex_fixed::TimeProfile
     directions::Int # 1: Unidirectional or 2: Bidirectional
-    data::Vector{Data}
+    data::Vector{<:ExtensionData}
 end
 function RefDynamic(
         id::String,
@@ -45,7 +45,7 @@ function RefDynamic(
         opex_fixed::TimeProfile,
         directions::Int,
     )
-    return RefDynamic(id, resource, trans_cap, trans_loss, opex_var, opex_fixed, directions, Data[])
+    return RefDynamic(id, resource, trans_cap, trans_loss, opex_var, opex_fixed, directions, ExtensionData[])
 end
 
 """
@@ -65,8 +65,8 @@ Generic representation of static transmission modes, such as overhead power line
 - **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.
 - **`directions`** is the number of directions the resource can be transported,
   1 is unidirectional (A->B) or 2 is bidirectional (A<->B).
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments). The field `data`
-  is conditional through usage of a constructor.
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
+  The field `data` is conditional through usage of a constructor.
 """
 struct RefStatic <: TransmissionMode # E.g. overhead power lines, pipelines etc.
     id::String
@@ -76,7 +76,7 @@ struct RefStatic <: TransmissionMode # E.g. overhead power lines, pipelines etc.
     opex_var::TimeProfile
     opex_fixed::TimeProfile
     directions::Int
-    data::Vector{Data}
+    data::Vector{<:ExtensionData}
 end
 function RefStatic(
         id::String,
@@ -87,7 +87,7 @@ function RefStatic(
         opex_fixed::TimeProfile,
         directions::Int,
     )
-    return RefStatic(id, resource, trans_cap, trans_loss, opex_var, opex_fixed, directions, Data[])
+    return RefStatic(id, resource, trans_cap, trans_loss, opex_var, opex_fixed, directions, ExtensionData[])
 end
 
 
@@ -132,8 +132,8 @@ be consumed at the wrong `Area`.
   modelled as a ratio.
 - **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.
 - **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments). The field `data`
-  is conditional through usage of a constructor.
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
+  The field `data` is conditional through usage of a constructor.
 """
 struct PipeSimple <: PipeMode
     id::String
@@ -145,7 +145,7 @@ struct PipeSimple <: PipeMode
     trans_loss::TimeProfile
     opex_var::TimeProfile
     opex_fixed::TimeProfile
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function PipeSimple(
     id::String,
@@ -168,7 +168,7 @@ function PipeSimple(
         trans_loss,
         opex_var,
         opex_fixed,
-        Data[],
+        ExtensionData[],
         )
 end
 
@@ -191,8 +191,8 @@ Pipeline model with linepacking implemented as simple storage function.
 - **`opex_var::TimeProfile`** is the variable operating expense per energy unit transported.
 - **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity.
 - **`energy_share::Float64`** is the storage energy capacity relative to pipeline capacity.
-- **`data::Array{<:Data}`** is the additional data (*e.g.*, for investments). The field `data`
-  is conditional through usage of a constructor.
+- **`data::Array{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
+  The field `data` is conditional through usage of a constructor.
 """
 struct PipeLinepackSimple <: PipeMode
     id::String
@@ -205,7 +205,7 @@ struct PipeLinepackSimple <: PipeMode
     opex_var::TimeProfile
     opex_fixed::TimeProfile
     energy_share::Float64
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function PipeLinepackSimple(
     id::String,
@@ -231,7 +231,7 @@ function PipeLinepackSimple(
         opex_var,
         opex_fixed,
         energy_share,
-        Data[])
+        ExtensionData[])
 end
 
 """
@@ -387,6 +387,6 @@ is_bidirectional(tm::PipeMode) = false
 """
     mode_data(tm::TransmissionMode)
 
-Returns the [`Data`](@extref EnergyModelsBase.Data) array of transmission mode `tm`.
+Returns the [`ExtensionData`](@extref EnergyModelsBase.ExtensionData) array of transmission mode `tm`.
 """
-mode_data(tm::TransmissionMode) = tm.data
+mode_data(tm::TransmissionMode) = hasproperty(tm, :data) ? tm.data : ExtensionData

--- a/test/test_emissions.jl
+++ b/test/test_emissions.jl
@@ -8,7 +8,7 @@ struct EmissionMode <: TransmissionMode
     opex_fixed::TimeProfile
     emissions::Dict{<:ResourceEmit, <:TimeProfile}
     directions::Int
-    data::Vector{Data}
+    data::Vector{ExtensionData}
 end
 EMB.has_emissions(tm::EmissionMode) = true
 EMG.emit_resources(tm::EmissionMode) = keys(tm.emissions)
@@ -83,7 +83,7 @@ function simple_case_emissions(
         FixedProfile(0),
         Dict(CO2 => FixedProfile(.5)),
         directions,
-        Data[],
+        ExtensionData[],
     )
 
     transmissions = [Transmission(areas[1], areas[2], [em_mode])]

--- a/test/test_geo_bidirectional.jl
+++ b/test/test_geo_bidirectional.jl
@@ -25,14 +25,14 @@ function bidirectional_case()
     nodes = [
             EMG.GeoAvailability(1, products),
             RefSource(2, FixedProfile(200), OperationalProfile([10, 100]), FixedProfile(0), Dict(NG => 1)),
-            RefNetworkNode(3, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1), Data[]),
+            RefNetworkNode(3, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1), ExtensionData[]),
             RefSink(4, OperationalProfile(demand),
                 Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
                 Dict(Power => 1)),
 
             EMG.GeoAvailability(5, products),
             RefSource(6, FixedProfile(200), OperationalProfile([100, 10]), FixedProfile(0), Dict(NG => 1)),
-            RefNetworkNode(7, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1), Data[]),
+            RefNetworkNode(7, FixedProfile(100), FixedProfile(5.5), FixedProfile(0), Dict(NG => 2), Dict(Power => 1), ExtensionData[]),
             RefSink(8, OperationalProfile(demand),
                 Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
                 Dict(Power => 1)),

--- a/test/test_geo_opex.jl
+++ b/test/test_geo_opex.jl
@@ -103,6 +103,7 @@ end
     end
     EMG.has_opex(tm::NoOPEXMode) = false
     EMG.is_bidirectional(tm::NoOPEXMode) = false
+    EMG.mode_data(tm::NoOPEXMode) = ExtensionData[]
 
     # Definition of the individual resources used in the simple system
     Power = ResourceCarrier("Power", 0.)

--- a/test/test_investments.jl
+++ b/test/test_investments.jl
@@ -22,7 +22,7 @@ function small_graph_geo(; source = nothing, sink = nothing, inv_data = nothing)
             FixedProfile(10),
             FixedProfile(5),
             Dict(Power => 1),
-            Array{Data}([]),
+            Array{ExtensionData}([]),
         )
     end
 
@@ -48,7 +48,7 @@ function small_graph_geo(; source = nothing, sink = nothing, inv_data = nothing)
     ]
 
     if isnothing(inv_data)
-        inv_data = Data[]
+        inv_data = ExtensionData[]
     else
         inv_data = [inv_data]
     end
@@ -107,11 +107,11 @@ end
     ) == length(𝒯)
 
     # Test showing that no investment variables are created
-    @test isempty((m[:trans_cap_current]))
-    @test isempty((m[:trans_cap_add]))
-    @test isempty((m[:trans_cap_rem]))
-    @test isempty((m[:trans_cap_invest_b]))
-    @test isempty((m[:trans_cap_remove_b]))
+    @test !haskey(m, :trans_cap_current)
+    @test !haskey(m, :trans_cap_add)
+    @test !haskey(m, :trans_cap_rem)
+    @test !haskey(m, :trans_cap_invest_b)
+    @test !haskey(m, :trans_cap_remove_b)
 end
 
 # Test set for continuous investments

--- a/test/test_mode.jl
+++ b/test/test_mode.jl
@@ -241,7 +241,7 @@ end
             FixedProfile(0.1),
             FixedProfile(1),
             2,
-            Data[EmptyData()]
+            ExtensionData[]
         )
         case, modeltype = simple_geo_uni(mode)
 
@@ -281,7 +281,7 @@ end
         @test all(EMG.emissions(mode, CO2, t) == 0 for t ∈ 𝒯)
 
 
-        @test mode_data(tm) == Data[EmptyData()]
+        @test mode_data(tm) == ExtensionData[]
     end
 
     @testset "PipeMode and PipeLinepackSimple" begin


### PR DESCRIPTION
This adjustment is not strictly necessary at the moment but as outlined in  *[Issue 64 of `EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/issues/64)*, the backward compatbility will be removed at one point.

It hence includes the following changes:

- Data replaced through `ExtensionData`
- Investment variables through `variables_ext_data`

Note that I had to create a new method for `Transmission` for `variables_element_ext_data` as we do not add extension data to `Transmission`, but to `TransmissionMode`.