### PR TITLE
Make the GeoAvailability constructor more flexible

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 0.11.5 (2026-01-06)
+
+### Adjustments
+
+* Make the `GeoAvailability(id, 𝒫::Array{Resource})` constructor more flexible (enabling, e.g., `GeoAvailability("av", [ResourceCarrier("Power", 0.0)])`).
+
 ## Version 0.11.4 (2025-12-16)
 
 ### Minor updates

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsGeography"
 uuid = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 authors = ["Espen Flo Bødal <Espen.Bodal@sintef.no>"]
-version = "0.11.4"
+version = "0.11.5"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/src/structures/area.jl
+++ b/src/structures/area.jl
@@ -67,10 +67,10 @@ changed mass balance.
 """
 struct GeoAvailability <: EMB.Availability
     id
-    input::Array{Resource}
-    output::Array{Resource}
+    input::Array{<:Resource}
+    output::Array{<:Resource}
 end
-GeoAvailability(id, 𝒫::Array{Resource}) = GeoAvailability(id, 𝒫, 𝒫)
+GeoAvailability(id, 𝒫::Array{<:Resource}) = GeoAvailability(id, 𝒫, 𝒫)
 
 """
     name(a::Area)

--- a/src/structures/area.jl
+++ b/src/structures/area.jl
@@ -53,9 +53,9 @@ struct LimitedExchangeArea <: Area
 end
 
 """
-    GeoAvailability <: EMB.Availability
+    struct GeoAvailability <: EMB.Availability
 
-A geography `Availability` node for substituion of the general
+A geography `Availability` node for substitution of the general
 [`GenAvailability`](@extref EnergyModelsBase.GenAvailability) node. A `GeoAvailability` is
 required if transmission should be included between individual [`Area`](@ref)s due to a
 changed mass balance.
@@ -64,6 +64,10 @@ changed mass balance.
 - **`id`** is the name/identifier of the node.
 - **`inputs::Vector{<:Resource}`** are the input [`Resource`](@extref EnergyModelsBase.Resource)s.
 - **`output::Vector{<:Resource}`** are the output [`Resource`](@extref EnergyModelsBase.Resource)s.
+
+A constructor is provided so that only a single array can be provided with the fields:
+- **`id`** is the name/identifier of the node.
+- **`𝒫::Vector{<:Resource}`** are the [`Resource`](@extref EnergyModelsBase.Resource)s.
 """
 struct GeoAvailability <: EMB.Availability
     id


### PR DESCRIPTION
This PR makes the `GeoAvailability(id, 𝒫::Array{Resource})` constructor more flexible (enabling, e.g., `GeoAvailability("av", [ResourceCarrier("Power", 0.0)])`). 

This also resolves a bug in EnergyModelsInputs.