### PR TITLE
Adjustments to EMI v0.9 and EMB v0.10

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## Unversioned
+
+### Breaking changes
+
+* Adjusted to the changes introduced in [`EnergyModelsInvestments` 0.9](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/releases/tag/v0.9.0) and [`EnergyModelsBase` 0.10](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0):
+  * Breaking change required as early retirement is now allowed.
+  * Changed the function call arguments for [`add_investment_constraints`](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/blob/0c84eb4fabdf6f3c188812a3555b40f2681e916b/src/model.jl#L1).
+  * Adjustment can change model behavior and results.
+
 ## Version 0.11.6 (2026-04-15)
 
 ### Add support for resource-specific constraint functions

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsGeography"
 uuid = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 authors = ["Espen Flo Bødal <Espen.Bodal@sintef.no>"]
-version = "0.11.6"
+version = "0.12.0"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -16,7 +16,8 @@ EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 EMIExt = "EnergyModelsInvestments"
 
 [compat]
-EnergyModelsBase = "0.9.5"
+EnergyModelsBase = "0.10"
+EnergyModelsInvestments = "0.9"
 SparseVariables = "0.7.3"
 JuMP = "1.5"
 TimeStruct = "0.9"

--- a/ext/EMIExt/model.jl
+++ b/ext/EMIExt/model.jl
@@ -88,10 +88,9 @@ function EMG.constraints_capacity_installed(
         # Extract the investment data and the discount rate
         disc_rate = discount_rate(modeltype)
         inv_data = EMI.investment_data(tm, :cap)
-        𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
         # Add the investment constraints
-        EMI.add_investment_constraints(m, tm, inv_data, :cap, :trans_cap, 𝒯ᴵⁿᵛ, disc_rate)
+        EMI.add_investment_constraints(m, tm, inv_data, :cap, :trans_cap, 𝒯, disc_rate)
     else
         for t ∈ 𝒯
             fix(m[:trans_cap][tm, t], EMB.capacity(tm, t); force=true)


### PR DESCRIPTION
This PR is adjusting to the changes introduced in [`EnergyModelsInvestments` v0.9](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/releases/tag/v0.9.0) and the related changes in [`EnergyModelsBase` v0.10](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0).

Specifically, it changes the function call argument for [`add_investment_constraints`](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/blob/0c84eb4fabdf6f3c188812a3555b40f2681e916b/src/model.jl#L1) and the value in the test set as early retirement is allowed.

> [!IMPORTANT]  
> There will be other PRs before registering to include additional changes to the documentation and removal of legacy constructors..